### PR TITLE
Less generation in case of not defined details

### DIFF
--- a/emi-web/docs/js/emi-javascript-web-socket.mdx
+++ b/emi-web/docs/js/emi-javascript-web-socket.mdx
@@ -74,7 +74,6 @@ import {
 export type UserStreamActionOptions = {
   queryKey?: unknown[];
   qs?: UserStreamActionQueryParams;
-  headers?: UserStreamActionReqHeaders;
 };
 /**
  * UserStreamAction
@@ -327,36 +326,5 @@ export type UserStreamActionResType = {
 };
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace UserStreamActionResType {}
-/**
- * UserStreamActionReqHeaders class
- * Auto-generated from EmiAction
- */
-export class UserStreamActionReqHeaders extends Headers {
-  /**
-   * @returns {Record<string, string>}
-   * Converts Headers to plain object
-   */
-  toObject() {
-    return Object.fromEntries(this.entries());
-  }
-}
-/**
- * UserStreamActionResHeaders class
- * Auto-generated from EmiAction
- */
-export class UserStreamActionResHeaders extends Headers {
-  /**
-   * @returns {Record<string, string>}
-   * Converts Headers to plain object
-   */
-  toObject() {
-    return Object.fromEntries(this.entries());
-  }
-}
-/**
- * UserStreamActionQueryParams class
- * Auto-generated from EmiAction
- */
-export class UserStreamActionQueryParams extends URLSearchParamsX {}
 
 ```

--- a/emi-web/docs/js/emi-javascript-web-socket.mdx
+++ b/emi-web/docs/js/emi-javascript-web-socket.mdx
@@ -61,29 +61,23 @@ actions:
        
       
 ```ts
-import {
-  URLSearchParamsX,
-  WebSocketX,
-  buildUrl,
-  isPlausibleObject,
-  withPrefix,
-} from "./sdk/js";
+import { WebSocketX, buildUrl, isPlausibleObject, withPrefix } from "./sdk/js";
 /**
  * Action to communicate with the action userStream
  */
 export type UserStreamActionOptions = {
   queryKey?: unknown[];
-  qs?: UserStreamActionQueryParams;
+  qs?: URLSearchParams;
 };
 /**
  * UserStreamAction
  */
 export class UserStreamAction {
   static URL = "ws://localhost:8081";
-  static NewUrl = (qs?: UserStreamActionQueryParams) =>
+  static NewUrl = (qs?: URLSearchParams) =>
     buildUrl(UserStreamAction.URL, undefined, qs);
   static Method = "reactive";
-  static Create = (overrideUrl?: string, qs?: UserStreamActionQueryParams) => {
+  static Create = (overrideUrl?: string, qs?: URLSearchParams) => {
     const url = overrideUrl ?? UserStreamAction.NewUrl(qs);
     return new WebSocketX<UserStreamActionReq, UserStreamActionRes>(
       url,

--- a/examples/js-test/reactclient/src/generated/GetSinglePostAction.ts
+++ b/examples/js-test/reactclient/src/generated/GetSinglePostAction.ts
@@ -1,4 +1,4 @@
-import { URLSearchParamsX, buildUrl, fetchx, isPlausibleObject, type TypedRequestInit, withPrefix } from './sdk/js';
+import { SSEFetch, buildUrl, fetchx, isPlausibleObject, type TypedRequestInit, withPrefix } from './sdk/js';
 import { type AxiosInstance, type AxiosRequestConfig, type AxiosResponse } from 'axios';
 import { type UseQueryOptions, useQuery } from '@tanstack/react-query';
 /**
@@ -7,7 +7,7 @@ import { type UseQueryOptions, useQuery } from '@tanstack/react-query';
 export type GetSinglePostActionOptions = {
 	queryKey?: unknown[];
 	params: GetSinglePostActionPathParameter;
-	qs?: GetSinglePostActionQueryParams;
+	qs?: URLSearchParams;
 };
 export type GetSinglePostActionQueryOptions = Omit<
 	UseQueryOptions<
@@ -53,7 +53,7 @@ export class GetSinglePostAction {
   static URL = 'https://jsonplaceholder.typicode.com/posts/:id';
   static NewUrl = (
 	params: GetSinglePostActionPathParameter,
-	qs?: GetSinglePostActionQueryParams
+	qs?: URLSearchParams
   ) => buildUrl(
 		GetSinglePostAction.URL,
 		params,
@@ -62,9 +62,10 @@ export class GetSinglePostAction {
   static Method = 'get';
 	static Fetch = async (
 			params: GetSinglePostActionPathParameter,
-		qs?: GetSinglePostActionQueryParams,
+		qs?: URLSearchParams,
 		init?: TypedRequestInit<GetSinglePostActionRes, unknown>,
-		overrideUrl?: string
+		onMessage?: (ev: MessageEvent) => void,
+		overrideUrl?: string,
 	) => {
 		const res = await fetchx<GetSinglePostActionRes, unknown, unknown>(
 			overrideUrl ?? GetSinglePostAction.NewUrl(
@@ -76,8 +77,23 @@ export class GetSinglePostAction {
 				...(init || {})
 			}
 		)
-			const result = await res.json();
+			const ct = res.headers.get("content-type") || "";
+			const cd = res.headers.get("content-disposition") || "";
+			if (ct.includes("text/event-stream")) {
+				// delegate to SSEFetch
+				return SSEFetch(res, onMessage, init?.signal);
+			}
+			if (cd.includes("attachment") || (!ct.includes("json") && !ct.startsWith("text/"))) {
+				res.result = res.body;
+				return res;
+			}
+			if (ct.includes("application/json")) {
+				const json = await res.json();
 				res.result = new GetSinglePostActionRes (result);
+				return res;
+			}
+			// plain text or fallback
+			res.result = await res.text();
 			return res;
 	}
 	static Axios : (

--- a/examples/js-test/reactclient/src/generated/GetSinglePostAction.ts
+++ b/examples/js-test/reactclient/src/generated/GetSinglePostAction.ts
@@ -8,7 +8,6 @@ export type GetSinglePostActionOptions = {
 	queryKey?: unknown[];
 	params: GetSinglePostActionPathParameter;
 	qs?: GetSinglePostActionQueryParams;
-	headers?: GetSinglePostActionReqHeaders;
 };
 export type GetSinglePostActionQueryOptions = Omit<
 	UseQueryOptions<
@@ -64,10 +63,10 @@ export class GetSinglePostAction {
 	static Fetch = async (
 			params: GetSinglePostActionPathParameter,
 		qs?: GetSinglePostActionQueryParams,
-		init?: TypedRequestInit<GetSinglePostActionRes, GetSinglePostActionReqHeaders>,
+		init?: TypedRequestInit<GetSinglePostActionRes, unknown>,
 		overrideUrl?: string
 	) => {
-		const res = await fetchx<GetSinglePostActionRes, unknown, GetSinglePostActionReqHeaders>(
+		const res = await fetchx<GetSinglePostActionRes, unknown, unknown>(
 			overrideUrl ?? GetSinglePostAction.NewUrl(
 				params,
 				qs
@@ -271,36 +270,4 @@ export abstract class GetSinglePostActionResFactory {
 	}
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace GetSinglePostActionResType {
-}
-/**
- * GetSinglePostActionReqHeaders class
- * Auto-generated from EmiAction
- */
-export class GetSinglePostActionReqHeaders extends Headers {
-  /**
-   * @returns {Record<string, string>}
-   * Converts Headers to plain object
-   */
-  toObject() {
-    return Object.fromEntries(this.entries());
-  }
-}
-/**
- * GetSinglePostActionResHeaders class
- * Auto-generated from EmiAction
- */
-export class GetSinglePostActionResHeaders extends Headers {
-  /**
-   * @returns {Record<string, string>}
-   * Converts Headers to plain object
-   */
-  toObject() {
-    return Object.fromEntries(this.entries());
-  }
-}
-/**
- * GetSinglePostActionQueryParams class
- * Auto-generated from EmiAction
- */
-export class GetSinglePostActionQueryParams extends URLSearchParamsX {
 }

--- a/examples/js-test/reactclient/src/generated/SampleModuleAxiosClient.ts
+++ b/examples/js-test/reactclient/src/generated/SampleModuleAxiosClient.ts
@@ -1,5 +1,5 @@
 import { Axios, type AxiosRequestConfig, type AxiosResponse } from 'axios';
-import { GetSinglePostAction, GetSinglePostActionQueryParams, GetSinglePostActionReqHeaders, GetSinglePostActionRes, type GetSinglePostActionPathParameter } from './GetSinglePostAction';
+import { GetSinglePostAction, GetSinglePostActionQueryParams, GetSinglePostActionRes, type GetSinglePostActionPathParameter } from './GetSinglePostAction';
 /**
 * Axios bundle service
 */
@@ -28,12 +28,12 @@ export class SampleModuleAxiosClient extends Axios {
 		GetSinglePostAction(params: GetSinglePostActionPathParameter, config?: TypedAxiosRequestConfig<
 			unknown,
 			GetSinglePostActionQueryParams,
-			GetSinglePostActionReqHeaders
+			unknown
 		>) {
 		 	const url = GetSinglePostAction.NewUrl(
 				params
 			)
-			return this.request<GetSinglePostActionRes, TypedAxiosResponse<GetSinglePostActionRes, unknown, GetSinglePostActionReqHeaders>>(
+			return this.request<GetSinglePostActionRes, TypedAxiosResponse<GetSinglePostActionRes, unknown, unknown>>(
 				{
 					url,
 					method: GetSinglePostAction.Method,

--- a/examples/js-test/reactclient/src/generated/SampleModuleAxiosClient.ts
+++ b/examples/js-test/reactclient/src/generated/SampleModuleAxiosClient.ts
@@ -1,5 +1,5 @@
 import { Axios, type AxiosRequestConfig, type AxiosResponse } from 'axios';
-import { GetSinglePostAction, GetSinglePostActionQueryParams, GetSinglePostActionRes, type GetSinglePostActionPathParameter } from './GetSinglePostAction';
+import { GetSinglePostAction, GetSinglePostActionRes, type GetSinglePostActionPathParameter } from './GetSinglePostAction';
 /**
 * Axios bundle service
 */
@@ -27,7 +27,7 @@ export class SampleModuleAxiosClient extends Axios {
   }
 		GetSinglePostAction(params: GetSinglePostActionPathParameter, config?: TypedAxiosRequestConfig<
 			unknown,
-			GetSinglePostActionQueryParams,
+			unknown,
 			unknown
 		>) {
 		 	const url = GetSinglePostAction.NewUrl(

--- a/examples/js-test/reactclient/src/generated/SampleSseAction.ts
+++ b/examples/js-test/reactclient/src/generated/SampleSseAction.ts
@@ -6,11 +6,10 @@ import { useSse } from './sdk/react';
 export type SampleSseActionOptions = {
 	queryKey?: unknown[];
 	qs?: SampleSseActionQueryParams;
-	headers?: SampleSseActionReqHeaders;
 };
 export const useSampleSseAction = (options: {
 	qs?: SampleSseActionQueryParams,
-	init?: TypedRequestInit<SampleSseActionRes, SampleSseActionReqHeaders>,
+	init?: TypedRequestInit<SampleSseActionRes, unknown>,
 	overrideUrl?: string
 }) => {
 	return useSse(SampleSseAction.Fetch, options);
@@ -31,10 +30,10 @@ export class SampleSseAction {
 	static Fetch = async (
 			onMessage?: (ev: MessageEvent) => void,
 		qs?: SampleSseActionQueryParams,
-		init?: TypedRequestInit<SampleSseActionRes, SampleSseActionReqHeaders>,
+		init?: TypedRequestInit<SampleSseActionRes, unknown>,
 		overrideUrl?: string
 	) => {
-		const res = await fetchx<SampleSseActionRes, unknown, SampleSseActionReqHeaders>(
+		const res = await fetchx<SampleSseActionRes, unknown, unknown>(
 			overrideUrl ?? SampleSseAction.NewUrl(
 				qs
 			),
@@ -124,36 +123,4 @@ export abstract class SampleSseActionResFactory {
 	}
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace SampleSseActionResType {
-}
-/**
- * SampleSseActionReqHeaders class
- * Auto-generated from EmiAction
- */
-export class SampleSseActionReqHeaders extends Headers {
-  /**
-   * @returns {Record<string, string>}
-   * Converts Headers to plain object
-   */
-  toObject() {
-    return Object.fromEntries(this.entries());
-  }
-}
-/**
- * SampleSseActionResHeaders class
- * Auto-generated from EmiAction
- */
-export class SampleSseActionResHeaders extends Headers {
-  /**
-   * @returns {Record<string, string>}
-   * Converts Headers to plain object
-   */
-  toObject() {
-    return Object.fromEntries(this.entries());
-  }
-}
-/**
- * SampleSseActionQueryParams class
- * Auto-generated from EmiAction
- */
-export class SampleSseActionQueryParams extends URLSearchParamsX {
 }

--- a/examples/js-test/reactclient/src/generated/WebSocketOrgEchoAction.ts
+++ b/examples/js-test/reactclient/src/generated/WebSocketOrgEchoAction.ts
@@ -6,7 +6,6 @@ import { useWebSocketX } from './sdk/react';
 export type WebSocketOrgEchoActionOptions = {
 	queryKey?: unknown[];
 	qs?: WebSocketOrgEchoActionQueryParams;
-	headers?: WebSocketOrgEchoActionReqHeaders;
 };
 export const useWebSocketOrgEchoAction = (options?: {
 	qs?: WebSocketOrgEchoActionQueryParams,
@@ -497,36 +496,4 @@ export abstract class WebSocketOrgEchoActionResFactory {
 	}
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace WebSocketOrgEchoActionResType {
-}
-/**
- * WebSocketOrgEchoActionReqHeaders class
- * Auto-generated from EmiAction
- */
-export class WebSocketOrgEchoActionReqHeaders extends Headers {
-  /**
-   * @returns {Record<string, string>}
-   * Converts Headers to plain object
-   */
-  toObject() {
-    return Object.fromEntries(this.entries());
-  }
-}
-/**
- * WebSocketOrgEchoActionResHeaders class
- * Auto-generated from EmiAction
- */
-export class WebSocketOrgEchoActionResHeaders extends Headers {
-  /**
-   * @returns {Record<string, string>}
-   * Converts Headers to plain object
-   */
-  toObject() {
-    return Object.fromEntries(this.entries());
-  }
-}
-/**
- * WebSocketOrgEchoActionQueryParams class
- * Auto-generated from EmiAction
- */
-export class WebSocketOrgEchoActionQueryParams extends URLSearchParamsX {
 }

--- a/examples/js-test/reactclient/src/generated/WebSocketOrgEchoAction.ts
+++ b/examples/js-test/reactclient/src/generated/WebSocketOrgEchoAction.ts
@@ -1,14 +1,14 @@
-import { URLSearchParamsX, WebSocketX, buildUrl, isPlausibleObject, withPrefix } from './sdk/js';
+import { WebSocketX, buildUrl, isPlausibleObject, withPrefix } from './sdk/js';
 import { useWebSocketX } from './sdk/react';
 /**
 * Action to communicate with the action webSocketOrgEcho
 */
 export type WebSocketOrgEchoActionOptions = {
 	queryKey?: unknown[];
-	qs?: WebSocketOrgEchoActionQueryParams;
+	qs?: URLSearchParams;
 };
 export const useWebSocketOrgEchoAction = (options?: {
-	qs?: WebSocketOrgEchoActionQueryParams,
+	qs?: URLSearchParams,
 	overrideUrl?: string
 }) => {
 	return useWebSocketX(
@@ -21,7 +21,7 @@ export const useWebSocketOrgEchoAction = (options?: {
 export class WebSocketOrgEchoAction {
   static URL = 'wss://echo.websocket.org/.ws';
   static NewUrl = (
-	qs?: WebSocketOrgEchoActionQueryParams
+	qs?: URLSearchParams
   ) => buildUrl(
 		WebSocketOrgEchoAction.URL,
 		 undefined,
@@ -30,7 +30,7 @@ export class WebSocketOrgEchoAction {
   static Method = 'reactive';
 	static Create = (
 		overrideUrl?: string,
-		qs?: WebSocketOrgEchoActionQueryParams,
+		qs?: URLSearchParams,
 	) => {
 		const url = overrideUrl ?? WebSocketOrgEchoAction.NewUrl(
 			qs

--- a/lib/js/js-action-class-realms.go
+++ b/lib/js/js-action-class-realms.go
@@ -37,21 +37,23 @@ func JsActionManifestRealms(
 	}
 	isTypeScript := strings.Contains(ctx.Tags, GEN_TYPESCRIPT_COMPATIBILITY)
 
-	reqheaderctx := jsHeaderClassContext{
-		ClassName: fmt.Sprintf("%vReqHeaders", core.ToUpper(action.GetName())),
-	}
-
 	if action.HasRequestHeaders() {
-		reqheaderctx.Columns = action.GetRequestHeaders()
-	}
-	requestHeader, err := JsHeaderClass(reqheaderctx, ctx)
-	if err != nil {
-		return nil, nil, err
-	}
+		reqheaderctx := jsHeaderClassContext{
+			ClassName: fmt.Sprintf("%vReqHeaders", core.ToUpper(action.GetName())),
+		}
 
-	if requestHeader != nil {
-		deps = append(deps, requestHeader.CodeChunkDependenies...)
-		actionRealms.RequestHeadersClass = requestHeader
+		reqheaderctx.Columns = action.GetRequestHeaders()
+
+		requestHeader, err := JsHeaderClass(reqheaderctx, ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if requestHeader != nil {
+			deps = append(deps, requestHeader.CodeChunkDependenies...)
+			actionRealms.RequestHeadersClass = requestHeader
+		}
+
 	}
 
 	resheaderctx := jsHeaderClassContext{
@@ -115,8 +117,8 @@ func JsActionManifestRealms(
 		}
 	}
 
-	if requestHeader != nil {
-		token := findTokenByName(requestHeader.Tokens, TOKEN_ROOT_CLASS)
+	if actionRealms.RequestHeadersClass != nil {
+		token := findTokenByName(actionRealms.RequestHeadersClass.Tokens, TOKEN_ROOT_CLASS)
 		if token != nil {
 			optionsctx.RequestHeadersClassName = token.Value
 		}

--- a/lib/js/js-action-main-class.go
+++ b/lib/js/js-action-main-class.go
@@ -31,17 +31,17 @@ func JsActionFetchAndMetaData(action core.EmiRpcAction, realms jsActionRealms, c
 		UrlCreatorFunction: fmt.Sprintf("%v.NewUrl", className),
 		UrlMethod:          fmt.Sprintf("%v.Method", className),
 		EndpointUrl:        action.GetUrl(),
-
+		QueryStringClass:   "URLSearchParams",
 		// By default, use the classic http call
 		IsClassicHttpCall: true,
 		ActionMethod:      action.GetMethod(),
 	}
 
-	if action.MethodUpper() == EMI_METHOD_SSE {
-		fetchctx.IsClassicHttpCall = false
-		fetchctx.IsSSE = true
-		fetchctx.ActionMethod = "get"
-	}
+	// if action.MethodUpper() == EMI_METHOD_SSE {
+	// 	fetchctx.IsClassicHttpCall = false
+	// 	fetchctx.IsSSE = true
+	// 	fetchctx.ActionMethod = "get"
+	// }
 
 	if action.MethodUpper() == EMI_METHOD_REACTIVE {
 		fetchctx.IsClassicHttpCall = false

--- a/lib/js/js-action-manifest.go
+++ b/lib/js/js-action-manifest.go
@@ -124,16 +124,16 @@ func JsActionManifest(action core.EmiRpcAction, ctx core.MicroGenContext) (*core
 {{ b2s .realms.ResponseClass.ActualScript }}
 {{ end }}
 
-{{ if .reqHeaderCompiledClass }}
-{{ .reqHeaderCompiledClass }}
+{{ if .actionRealms.RequestHeadersClass }}
+{{ b2s .actionRealms.RequestHeadersClass.ActualScript }}
 {{ end }}
 
-{{ if .resHeaderCompiledClass }}
-{{ .resHeaderCompiledClass }}
+{{ if .actionRealms.ResponseHeadersClass }}
+{{ b2s .actionRealms.ResponseHeadersClass.ActualScript }}
 {{ end }}
 
-{{ if .qsCompiledClass }}
-{{ .qsCompiledClass }}
+{{ if .actionRealms.QueryStringClass }}
+{{ b2s .actionRealms.QueryStringClass.ActualScript }}
 {{ end }}
 
 `
@@ -143,16 +143,13 @@ func JsActionManifest(action core.EmiRpcAction, ctx core.MicroGenContext) (*core
 
 	var buf bytes.Buffer
 	if err := t.Execute(&buf, core.H{
-		"action":                 action,
-		"reqHeaderCompiledClass": string(actionRealms.RequestHeadersClass.ActualScript),
-		"resHeaderCompiledClass": string(actionRealms.ResponseHeadersClass.ActualScript),
-		"qsCompiledClass":        string(actionRealms.QueryStringClass.ActualScript),
-		"shouldExport":           true,
-		"reactQuery":             reactQuery,
-		"nestjsDecorator":        nestJsDecorator,
-		"fetch":                  string(actionRealms.FetchMetaClass.ActualScript),
-		"realms":                 actionRealms,
-		"className":              action.GetName(),
+		"action":          action,
+		"shouldExport":    true,
+		"reactQuery":      reactQuery,
+		"nestjsDecorator": nestJsDecorator,
+		"fetch":           string(actionRealms.FetchMetaClass.ActualScript),
+		"realms":          actionRealms,
+		"className":       action.GetName(),
 	}); err != nil {
 		return nil, err
 	}

--- a/lib/js/js-action-manifest.go
+++ b/lib/js/js-action-manifest.go
@@ -112,8 +112,8 @@ func JsActionManifest(action core.EmiRpcAction, ctx core.MicroGenContext) (*core
 {{ end }}
  
 
-{{ if .fetch }}
-	{{ .fetch }}
+{{ if .realms.FetchMetaClass }}
+	{{ b2s .realms.FetchMetaClass.ActualScript }}
 {{ end }}
 
 {{ if .realms.RequestClass }}
@@ -124,16 +124,16 @@ func JsActionManifest(action core.EmiRpcAction, ctx core.MicroGenContext) (*core
 {{ b2s .realms.ResponseClass.ActualScript }}
 {{ end }}
 
-{{ if .actionRealms.RequestHeadersClass }}
-{{ b2s .actionRealms.RequestHeadersClass.ActualScript }}
+{{ if .realms.RequestHeadersClass }}
+{{ b2s .realms.RequestHeadersClass.ActualScript }}
 {{ end }}
 
-{{ if .actionRealms.ResponseHeadersClass }}
-{{ b2s .actionRealms.ResponseHeadersClass.ActualScript }}
+{{ if .realms.ResponseHeadersClass }}
+{{ b2s .realms.ResponseHeadersClass.ActualScript }}
 {{ end }}
 
-{{ if .actionRealms.QueryStringClass }}
-{{ b2s .actionRealms.QueryStringClass.ActualScript }}
+{{ if .realms.QueryStringClass }}
+{{ b2s .realms.QueryStringClass.ActualScript }}
 {{ end }}
 
 `
@@ -147,7 +147,6 @@ func JsActionManifest(action core.EmiRpcAction, ctx core.MicroGenContext) (*core
 		"shouldExport":    true,
 		"reactQuery":      reactQuery,
 		"nestjsDecorator": nestJsDecorator,
-		"fetch":           string(actionRealms.FetchMetaClass.ActualScript),
 		"realms":          actionRealms,
 		"className":       action.GetName(),
 	}); err != nil {

--- a/lib/js/js-query-params.go
+++ b/lib/js/js-query-params.go
@@ -1,6 +1,6 @@
 // Contains code to generate type-safe query class for javascript, and typescript definitions
 // Basically, it would extend the queries class from native javascript, and add the keys there.
-// It's a direct drop in for UrlSearchParams, and works as expected with all libraries.
+// It's a direct drop in for URLSearchParams, and works as expected with all libraries.
 
 // When modifiying this file, test both js and ts definition are in sync.
 

--- a/tests/js/web-socket-test-output/UserStreamAction.ts
+++ b/tests/js/web-socket-test-output/UserStreamAction.ts
@@ -1,10 +1,10 @@
-import { URLSearchParamsX, WebSocketX, buildUrl, isPlausibleObject, withPrefix } from './sdk/js';
+import { WebSocketX, buildUrl, isPlausibleObject, withPrefix } from './sdk/js';
 /**
 * Action to communicate with the action userStream
 */
 export type UserStreamActionOptions = {
 	queryKey?: unknown[];
-	qs?: UserStreamActionQueryParams;
+	qs?: URLSearchParams;
 };
 	/**
  * UserStreamAction
@@ -12,7 +12,7 @@ export type UserStreamActionOptions = {
 export class UserStreamAction {
   static URL = 'ws://localhost:8081';
   static NewUrl = (
-	qs?: UserStreamActionQueryParams
+	qs?: URLSearchParams
   ) => buildUrl(
 		UserStreamAction.URL,
 		 undefined,
@@ -21,7 +21,7 @@ export class UserStreamAction {
   static Method = 'reactive';
 	static Create = (
 		overrideUrl?: string,
-		qs?: UserStreamActionQueryParams,
+		qs?: URLSearchParams,
 	) => {
 		const url = overrideUrl ?? UserStreamAction.NewUrl(
 			qs

--- a/tests/js/web-socket-test-output/UserStreamAction.ts
+++ b/tests/js/web-socket-test-output/UserStreamAction.ts
@@ -5,7 +5,6 @@ import { URLSearchParamsX, WebSocketX, buildUrl, isPlausibleObject, withPrefix }
 export type UserStreamActionOptions = {
 	queryKey?: unknown[];
 	qs?: UserStreamActionQueryParams;
-	headers?: UserStreamActionReqHeaders;
 };
 	/**
  * UserStreamAction
@@ -253,36 +252,4 @@ export abstract class UserStreamActionResFactory {
 	}
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace UserStreamActionResType {
-}
-/**
- * UserStreamActionReqHeaders class
- * Auto-generated from EmiAction
- */
-export class UserStreamActionReqHeaders extends Headers {
-  /**
-   * @returns {Record<string, string>}
-   * Converts Headers to plain object
-   */
-  toObject() {
-    return Object.fromEntries(this.entries());
-  }
-}
-/**
- * UserStreamActionResHeaders class
- * Auto-generated from EmiAction
- */
-export class UserStreamActionResHeaders extends Headers {
-  /**
-   * @returns {Record<string, string>}
-   * Converts Headers to plain object
-   */
-  toObject() {
-    return Object.fromEntries(this.entries());
-  }
-}
-/**
- * UserStreamActionQueryParams class
- * Auto-generated from EmiAction
- */
-export class UserStreamActionQueryParams extends URLSearchParamsX {
 }


### PR DESCRIPTION
Do not generate headers, query string, etc if not needed, fallback to standard ones.