### PR TITLE
Clean up tests, and interface for unknown primitives.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,3 +60,7 @@ go:
 
 nullabletest:
 	go test ./tests/nullable-test/...
+
+
+test_examples:
+	cd examples/fullstack && make

--- a/examples/fullstack/client-ts/AllDataAction.ts
+++ b/examples/fullstack/client-ts/AllDataAction.ts
@@ -1,0 +1,346 @@
+import { CommonVectorResponseDto } from "./CommonVectorResponseDto";
+import { buildUrl } from "./sdk/common/buildUrl";
+import {
+  fetchx,
+  handleFetchResponse,
+  type FetchxContext,
+  type PartialDeep,
+  type TypedRequestInit,
+  type TypedResponse,
+} from "./sdk/common/fetchx";
+import { type UseMutationOptions, useMutation } from "react-query";
+import { useFetchxContext } from "./sdk/react/useFetchx";
+import { useState } from "react";
+import { withPrefix } from "./sdk/common/withPrefix";
+/**
+ * Action to communicate with the action allData
+ */
+export type AllDataActionOptions = {
+  queryKey?: unknown[];
+  qs?: URLSearchParams;
+};
+export type AllDataActionMutationOptions = Omit<
+  UseMutationOptions<unknown, unknown, unknown, unknown>,
+  "mutationFn"
+> &
+  AllDataActionOptions & {
+    ctx?: FetchxContext;
+    onMessage?: (ev: MessageEvent) => void;
+    overrideUrl?: string;
+    headers?: Headers;
+  } & Partial<{
+    creatorFn: (item: unknown) => AllDataActionRes;
+  }>;
+export const useAllDataAction = (options?: AllDataActionMutationOptions) => {
+  const globalCtx = useFetchxContext();
+  const ctx = options?.ctx ?? globalCtx ?? undefined;
+  const [isCompleted, setCompleteState] = useState(false);
+  const [response, setResponse] = useState<TypedResponse<unknown>>();
+  const fn = (body: unknown) => {
+    setCompleteState(false);
+    return AllDataAction.Fetch(
+      {
+        body,
+        headers: options?.headers,
+      },
+      {
+        creatorFn: options?.creatorFn,
+        qs: options?.qs,
+        ctx,
+        onMessage: options?.onMessage,
+        overrideUrl: options?.overrideUrl,
+      },
+    ).then((x) => {
+      x.done.then(() => {
+        setCompleteState(true);
+      });
+      setResponse(x.response);
+      return x.response.result;
+    });
+  };
+  const result = useMutation({
+    mutationFn: fn,
+    ...(options || {}),
+  });
+  return {
+    ...result,
+    isCompleted,
+    response,
+  };
+};
+/**
+ * AllDataAction
+ */
+export class AllDataAction {
+  //
+  static URL = "/res/22";
+  static NewUrl = (qs?: URLSearchParams) =>
+    buildUrl(AllDataAction.URL, undefined, qs);
+  static Method = "";
+  static Fetch$ = async (
+    qs?: URLSearchParams,
+    ctx?: FetchxContext,
+    init?: TypedRequestInit<unknown, unknown>,
+    overrideUrl?: string,
+  ) => {
+    return fetchx<AllDataActionRes, unknown, unknown>(
+      overrideUrl ?? AllDataAction.NewUrl(qs),
+      {
+        method: AllDataAction.Method,
+        ...(init || {}),
+      },
+      ctx,
+    );
+  };
+  static Fetch = async (
+    init?: TypedRequestInit<unknown, unknown>,
+    {
+      creatorFn,
+      qs,
+      ctx,
+      onMessage,
+      overrideUrl,
+    }: {
+      creatorFn?: ((item: unknown) => AllDataActionRes) | undefined;
+      qs?: URLSearchParams;
+      ctx?: FetchxContext;
+      onMessage?: (ev: MessageEvent) => void;
+      overrideUrl?: string;
+    } = {
+      creatorFn: (item) => new AllDataActionRes(item),
+    },
+  ) => {
+    creatorFn = creatorFn || ((item) => new AllDataActionRes(item));
+    const res = await AllDataAction.Fetch$(qs, ctx, init, overrideUrl);
+    return handleFetchResponse(
+      res,
+      (item) => (creatorFn ? creatorFn(item) : item),
+      onMessage,
+      init?.signal,
+    );
+  };
+  static Definition = {
+    name: "allData",
+    url: "/res/22",
+    out: {
+      fields: [
+        {
+          name: "stringType",
+          type: "string",
+        },
+        {
+          name: "stringTypeNull",
+          type: "string?",
+        },
+        {
+          name: "collection",
+          type: "collection",
+          target: "CommonVectorResponseDto",
+        },
+      ],
+    },
+  };
+}
+/**
+ * The base class definition for allDataActionRes
+ **/
+export class AllDataActionRes {
+  /**
+   *
+   * @type {string}
+   **/
+  #stringType: string = "";
+  /**
+   *
+   * @returns {string}
+   **/
+  get stringType() {
+    return this.#stringType;
+  }
+  /**
+   *
+   * @type {string}
+   **/
+  set stringType(value: string) {
+    this.#stringType = String(value);
+  }
+  setStringType(value: string) {
+    this.stringType = value;
+    return this;
+  }
+  /**
+   *
+   * @type {string}
+   **/
+  #stringTypeNull?: string | null = undefined;
+  /**
+   *
+   * @returns {string}
+   **/
+  get stringTypeNull() {
+    return this.#stringTypeNull;
+  }
+  /**
+   *
+   * @type {string}
+   **/
+  set stringTypeNull(value: string | null | undefined) {
+    const correctType =
+      typeof value === "string" || value === undefined || value === null;
+    this.#stringTypeNull = correctType ? value : String(value);
+  }
+  setStringTypeNull(value: string | null | undefined) {
+    this.stringTypeNull = value;
+    return this;
+  }
+  /**
+   *
+   * @type {CommonVectorResponseDto[]}
+   **/
+  #collection: CommonVectorResponseDto[] = [];
+  /**
+   *
+   * @returns {CommonVectorResponseDto[]}
+   **/
+  get collection() {
+    return this.#collection;
+  }
+  /**
+   *
+   * @type {CommonVectorResponseDto[]}
+   **/
+  set collection(value: CommonVectorResponseDto[]) {
+    // For arrays, you only can pass arrays to the object
+    if (!Array.isArray(value)) {
+      return;
+    }
+    if (value.length > 0 && value[0] instanceof CommonVectorResponseDto) {
+      this.#collection = value;
+    } else {
+      this.#collection = value.map((item) => new CommonVectorResponseDto(item));
+    }
+  }
+  setCollection(value: CommonVectorResponseDto[]) {
+    this.collection = value;
+    return this;
+  }
+  constructor(data: unknown = undefined) {
+    if (data === null || data === undefined) {
+      return;
+    }
+    if (typeof data === "string") {
+      this.applyFromObject(JSON.parse(data));
+    } else if (this.#isJsonAppliable(data)) {
+      this.applyFromObject(data);
+    } else {
+      throw new Error(
+        "Instance cannot be created on an unknown value, check the content being passed. got: " +
+          typeof data,
+      );
+    }
+  }
+  #isJsonAppliable(obj: unknown) {
+    const g = globalThis as unknown as { Buffer: any; Blob: any };
+    const isBuffer =
+      typeof g.Buffer !== "undefined" &&
+      typeof g.Buffer.isBuffer === "function" &&
+      g.Buffer.isBuffer(obj);
+    const isBlob = typeof g.Blob !== "undefined" && obj instanceof g.Blob;
+    return (
+      obj &&
+      typeof obj === "object" &&
+      !Array.isArray(obj) &&
+      !isBuffer &&
+      !(obj instanceof ArrayBuffer) &&
+      !isBlob
+    );
+  }
+  /**
+   * casts the fields of a javascript object into the class properties one by one
+   **/
+  applyFromObject(data = {}) {
+    const d = data as Partial<AllDataActionRes>;
+    if (d.stringType !== undefined) {
+      this.stringType = d.stringType;
+    }
+    if (d.stringTypeNull !== undefined) {
+      this.stringTypeNull = d.stringTypeNull;
+    }
+    if (d.collection !== undefined) {
+      this.collection = d.collection;
+    }
+  }
+  /**
+   *	Special toJSON override, since the field are private,
+   *	Json stringify won't see them unless we mention it explicitly.
+   **/
+  toJSON() {
+    return {
+      stringType: this.#stringType,
+      stringTypeNull: this.#stringTypeNull,
+      collection: this.#collection,
+    };
+  }
+  toString() {
+    return JSON.stringify(this);
+  }
+  static get Fields() {
+    return {
+      stringType: "stringType",
+      stringTypeNull: "stringTypeNull",
+      collection$: "collection",
+      get collection() {
+        return withPrefix("collection[:i]", CommonVectorResponseDto.Fields);
+      },
+    };
+  }
+  /**
+   * Creates an instance of AllDataActionRes, and possibleDtoObject
+   * needs to satisfy the type requirement fully, otherwise typescript compile would
+   * be complaining.
+   **/
+  static from(possibleDtoObject: AllDataActionResType) {
+    return new AllDataActionRes(possibleDtoObject);
+  }
+  /**
+   * Creates an instance of AllDataActionRes, and partialDtoObject
+   * needs to satisfy the type, but partially, and rest of the content would
+   * be constructed according to data types and nullability.
+   **/
+  static with(partialDtoObject: PartialDeep<AllDataActionResType>) {
+    return new AllDataActionRes(partialDtoObject);
+  }
+  copyWith(
+    partial: PartialDeep<AllDataActionResType>,
+  ): InstanceType<typeof AllDataActionRes> {
+    return new AllDataActionRes({ ...this.toJSON(), ...partial });
+  }
+  clone(): InstanceType<typeof AllDataActionRes> {
+    return new AllDataActionRes(this.toJSON());
+  }
+}
+export abstract class AllDataActionResFactory {
+  abstract create(data: unknown): AllDataActionRes;
+}
+/**
+ * The base type definition for allDataActionRes
+ **/
+export type AllDataActionResType = {
+  /**
+   *
+   * @type {string}
+   **/
+  stringType: string;
+  /**
+   *
+   * @type {string}
+   **/
+  stringTypeNull?: string;
+  /**
+   *
+   * @type {CommonVectorResponseDto[]}
+   **/
+  collection: CommonVectorResponseDto[];
+};
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace AllDataActionResType {}

--- a/examples/fullstack/client-ts/CommonVectorComputeDto.ts
+++ b/examples/fullstack/client-ts/CommonVectorComputeDto.ts
@@ -1,3 +1,4 @@
+import { type PartialDeep } from "./sdk/common/fetchx";
 import { withPrefix } from "./sdk/common/withPrefix";
 /**
  * The base class definition for commonVectorComputeDto
@@ -19,7 +20,9 @@ export class CommonVectorComputeDto {
    *
    * @type {number[]}
    **/
-  set initialVector1(value: number[]) {}
+  set initialVector1(value: number[]) {
+    this.#initialVector1 = value;
+  }
   setInitialVector1(value: number[]) {
     this.initialVector1 = value;
     return this;
@@ -88,7 +91,9 @@ export class CommonVectorComputeDto {
    *
    * @type {number[]}
    **/
-  set initialVector2(value: number[]) {}
+  set initialVector2(value: number[]) {
+    this.#initialVector2 = value;
+  }
   setInitialVector2(value: number[]) {
     this.initialVector2 = value;
     return this;
@@ -151,7 +156,9 @@ export class CommonVectorComputeDto {
    *
    * @type {string[]}
    **/
-  set fieldTypeSlice(value: string[]) {}
+  set fieldTypeSlice(value: string[]) {
+    this.#fieldTypeSlice = value;
+  }
   setFieldTypeSlice(value: string[]) {
     this.fieldTypeSlice = value;
     return this;
@@ -227,7 +234,9 @@ export class CommonVectorComputeDto {
    *
    * @type {Money}
    **/
-  set complexMoney(value: Money) {}
+  set complexMoney(value: Money) {
+    this.#complexMoney = value;
+  }
   setComplexMoney(value: Money) {
     this.complexMoney = value;
     return this;
@@ -671,13 +680,6 @@ export class CommonVectorComputeDto {
 export abstract class CommonVectorComputeDtoFactory {
   abstract create(data: unknown): CommonVectorComputeDto;
 }
-type PartialDeep<T> = {
-  [P in keyof T]?: T[P] extends Array<infer U>
-    ? Array<PartialDeep<U>>
-    : T[P] extends object
-      ? PartialDeep<T[P]>
-      : T[P];
-};
 /**
  * The base type definition for commonVectorComputeDto
  **/

--- a/examples/fullstack/client-ts/CommonVectorResponseDto.ts
+++ b/examples/fullstack/client-ts/CommonVectorResponseDto.ts
@@ -1,4 +1,5 @@
 import { CommonVectorComputeDto } from "./CommonVectorComputeDto";
+import { type PartialDeep } from "./sdk/common/fetchx";
 import { withPrefix } from "./sdk/common/withPrefix";
 /**
  * The base class definition for commonVectorResponseDto
@@ -20,7 +21,9 @@ export class CommonVectorResponseDto {
    *
    * @type {number[]}
    **/
-  set outputVector(value: number[]) {}
+  set outputVector(value: number[]) {
+    this.#outputVector = value;
+  }
   setOutputVector(value: number[]) {
     this.outputVector = value;
     return this;
@@ -160,13 +163,6 @@ export class CommonVectorResponseDto {
 export abstract class CommonVectorResponseDtoFactory {
   abstract create(data: unknown): CommonVectorResponseDto;
 }
-type PartialDeep<T> = {
-  [P in keyof T]?: T[P] extends Array<infer U>
-    ? Array<PartialDeep<U>>
-    : T[P] extends object
-      ? PartialDeep<T[P]>
-      : T[P];
-};
 /**
  * The base type definition for commonVectorResponseDto
  **/

--- a/examples/fullstack/client-ts/ComputeApiAction.ts
+++ b/examples/fullstack/client-ts/ComputeApiAction.ts
@@ -1,12 +1,13 @@
+import { URLSearchParamsX } from "./sdk/common/URLSearchParamsX";
+import { buildUrl } from "./sdk/common/buildUrl";
 import {
-  type FetchxContext,
   fetchx,
   handleFetchResponse,
+  type FetchxContext,
+  type PartialDeep,
   type TypedRequestInit,
   type TypedResponse,
 } from "./sdk/common/fetchx";
-import { URLSearchParamsX } from "./sdk/common/URLSearchParamsX";
-import { buildUrl } from "./sdk/common/buildUrl";
 import { type UseMutationOptions, useMutation } from "react-query";
 import { useFetchxContext } from "./sdk/react/useFetchx";
 import { useState } from "react";
@@ -114,7 +115,7 @@ export class ComputeApiAction {
     const res = await ComputeApiAction.Fetch$(qs, ctx, init, overrideUrl);
     return handleFetchResponse(
       res,
-      (item) => creatorFn(item),
+      (item) => (creatorFn ? creatorFn(item) : item),
       onMessage,
       init?.signal,
     );
@@ -184,7 +185,9 @@ export class ComputeApiActionReq {
    *
    * @type {number[]}
    **/
-  set initialVector1(value: number[]) {}
+  set initialVector1(value: number[]) {
+    this.#initialVector1 = value;
+  }
   setInitialVector1(value: number[]) {
     this.initialVector1 = value;
     return this;
@@ -230,7 +233,9 @@ export class ComputeApiActionReq {
    *
    * @type {number[]}
    **/
-  set initialVector2(value: number[]) {}
+  set initialVector2(value: number[]) {
+    this.#initialVector2 = value;
+  }
   setInitialVector2(value: number[]) {
     this.initialVector2 = value;
     return this;
@@ -336,13 +341,6 @@ export class ComputeApiActionReq {
 export abstract class ComputeApiActionReqFactory {
   abstract create(data: unknown): ComputeApiActionReq;
 }
-type PartialDeep<T> = {
-  [P in keyof T]?: T[P] extends Array<infer U>
-    ? Array<PartialDeep<U>>
-    : T[P] extends object
-      ? PartialDeep<T[P]>
-      : T[P];
-};
 /**
  * The base type definition for computeApiActionReq
  **/
@@ -385,7 +383,9 @@ export class ComputeApiActionRes {
    *
    * @type {number[]}
    **/
-  set outputVector(value: number[]) {}
+  set outputVector(value: number[]) {
+    this.#outputVector = value;
+  }
   setOutputVector(value: number[]) {
     this.outputVector = value;
     return this;
@@ -478,13 +478,6 @@ export class ComputeApiActionRes {
 export abstract class ComputeApiActionResFactory {
   abstract create(data: unknown): ComputeApiActionRes;
 }
-type PartialDeep<T> = {
-  [P in keyof T]?: T[P] extends Array<infer U>
-    ? Array<PartialDeep<U>>
-    : T[P] extends object
-      ? PartialDeep<T[P]>
-      : T[P];
-};
 /**
  * The base type definition for computeApiActionRes
  **/

--- a/examples/fullstack/client-ts/ComputeApiSseAction.ts
+++ b/examples/fullstack/client-ts/ComputeApiSseAction.ts
@@ -1,11 +1,12 @@
+import { buildUrl } from "./sdk/common/buildUrl";
 import {
-  FetchxContext,
   fetchx,
   handleFetchResponse,
+  type FetchxContext,
+  type PartialDeep,
   type TypedRequestInit,
   type TypedResponse,
 } from "./sdk/common/fetchx";
-import { buildUrl } from "./sdk/common/buildUrl";
 import {
   type UseMutationOptions,
   type UseQueryOptions,
@@ -170,7 +171,7 @@ export class ComputeApiSseAction {
     const res = await ComputeApiSseAction.Fetch$(qs, ctx, init, overrideUrl);
     return handleFetchResponse(
       res,
-      (item) => creatorFn(item),
+      (item) => (creatorFn ? creatorFn(item) : item),
       onMessage,
       init?.signal,
     );
@@ -230,7 +231,9 @@ export class ComputeApiSseActionReq {
    *
    * @type {number[]}
    **/
-  set initialVector1(value: number[]) {}
+  set initialVector1(value: number[]) {
+    this.#initialVector1 = value;
+  }
   setInitialVector1(value: number[]) {
     this.initialVector1 = value;
     return this;
@@ -276,7 +279,9 @@ export class ComputeApiSseActionReq {
    *
    * @type {number[]}
    **/
-  set initialVector2(value: number[]) {}
+  set initialVector2(value: number[]) {
+    this.#initialVector2 = value;
+  }
   setInitialVector2(value: number[]) {
     this.initialVector2 = value;
     return this;
@@ -382,13 +387,6 @@ export class ComputeApiSseActionReq {
 export abstract class ComputeApiSseActionReqFactory {
   abstract create(data: unknown): ComputeApiSseActionReq;
 }
-type PartialDeep<T> = {
-  [P in keyof T]?: T[P] extends Array<infer U>
-    ? Array<PartialDeep<U>>
-    : T[P] extends object
-      ? PartialDeep<T[P]>
-      : T[P];
-};
 /**
  * The base type definition for computeApiSseActionReq
  **/
@@ -431,7 +429,9 @@ export class ComputeApiSseActionRes {
    *
    * @type {number[]}
    **/
-  set outputVector(value: number[]) {}
+  set outputVector(value: number[]) {
+    this.#outputVector = value;
+  }
   setOutputVector(value: number[]) {
     this.outputVector = value;
     return this;
@@ -524,13 +524,6 @@ export class ComputeApiSseActionRes {
 export abstract class ComputeApiSseActionResFactory {
   abstract create(data: unknown): ComputeApiSseActionRes;
 }
-type PartialDeep<T> = {
-  [P in keyof T]?: T[P] extends Array<infer U>
-    ? Array<PartialDeep<U>>
-    : T[P] extends object
-      ? PartialDeep<T[P]>
-      : T[P];
-};
 /**
  * The base type definition for computeApiSseActionRes
  **/

--- a/examples/fullstack/client-ts/ComputeApiSseChannelAction.ts
+++ b/examples/fullstack/client-ts/ComputeApiSseChannelAction.ts
@@ -1,11 +1,12 @@
+import { buildUrl } from "./sdk/common/buildUrl";
 import {
-  FetchxContext,
   fetchx,
   handleFetchResponse,
+  type FetchxContext,
+  type PartialDeep,
   type TypedRequestInit,
   type TypedResponse,
 } from "./sdk/common/fetchx";
-import { buildUrl } from "./sdk/common/buildUrl";
 import {
   type UseMutationOptions,
   type UseQueryOptions,
@@ -182,7 +183,7 @@ export class ComputeApiSseChannelAction {
     );
     return handleFetchResponse(
       res,
-      (item) => creatorFn(item),
+      (item) => (creatorFn ? creatorFn(item) : item),
       onMessage,
       init?.signal,
     );
@@ -242,7 +243,9 @@ export class ComputeApiSseChannelActionReq {
    *
    * @type {number[]}
    **/
-  set initialVector1(value: number[]) {}
+  set initialVector1(value: number[]) {
+    this.#initialVector1 = value;
+  }
   setInitialVector1(value: number[]) {
     this.initialVector1 = value;
     return this;
@@ -288,7 +291,9 @@ export class ComputeApiSseChannelActionReq {
    *
    * @type {number[]}
    **/
-  set initialVector2(value: number[]) {}
+  set initialVector2(value: number[]) {
+    this.#initialVector2 = value;
+  }
   setInitialVector2(value: number[]) {
     this.initialVector2 = value;
     return this;
@@ -396,13 +401,6 @@ export class ComputeApiSseChannelActionReq {
 export abstract class ComputeApiSseChannelActionReqFactory {
   abstract create(data: unknown): ComputeApiSseChannelActionReq;
 }
-type PartialDeep<T> = {
-  [P in keyof T]?: T[P] extends Array<infer U>
-    ? Array<PartialDeep<U>>
-    : T[P] extends object
-      ? PartialDeep<T[P]>
-      : T[P];
-};
 /**
  * The base type definition for computeApiSseChannelActionReq
  **/
@@ -445,7 +443,9 @@ export class ComputeApiSseChannelActionRes {
    *
    * @type {number[]}
    **/
-  set outputVector(value: number[]) {}
+  set outputVector(value: number[]) {
+    this.#outputVector = value;
+  }
   setOutputVector(value: number[]) {
     this.outputVector = value;
     return this;
@@ -540,13 +540,6 @@ export class ComputeApiSseChannelActionRes {
 export abstract class ComputeApiSseChannelActionResFactory {
   abstract create(data: unknown): ComputeApiSseChannelActionRes;
 }
-type PartialDeep<T> = {
-  [P in keyof T]?: T[P] extends Array<infer U>
-    ? Array<PartialDeep<U>>
-    : T[P] extends object
-      ? PartialDeep<T[P]>
-      : T[P];
-};
 /**
  * The base type definition for computeApiSseChannelActionRes
  **/

--- a/examples/fullstack/client-ts/ComputeExpAction.ts
+++ b/examples/fullstack/client-ts/ComputeExpAction.ts
@@ -1,11 +1,12 @@
+import { buildUrl } from "./sdk/common/buildUrl";
 import {
-  FetchxContext,
   fetchx,
   handleFetchResponse,
+  type FetchxContext,
+  type PartialDeep,
   type TypedRequestInit,
   type TypedResponse,
 } from "./sdk/common/fetchx";
-import { buildUrl } from "./sdk/common/buildUrl";
 import { type UseMutationOptions, useMutation } from "react-query";
 import { useFetchxContext } from "./sdk/react/useFetchx";
 import { useState } from "react";
@@ -132,7 +133,7 @@ export class ComputeExpAction {
     );
     return handleFetchResponse(
       res,
-      (item) => creatorFn(item),
+      (item) => (creatorFn ? creatorFn(item) : item),
       onMessage,
       init?.signal,
     );
@@ -186,7 +187,9 @@ export class ComputeExpActionReq {
    *
    * @type {Int}
    **/
-  set base(value: Int) {}
+  set base(value: Int) {
+    this.#base = value;
+  }
   setBase(value: Int) {
     this.base = value;
     return this;
@@ -207,7 +210,9 @@ export class ComputeExpActionReq {
    *
    * @type {Int}
    **/
-  set exponent(value: Int) {}
+  set exponent(value: Int) {
+    this.#exponent = value;
+  }
   setExponent(value: Int) {
     this.exponent = value;
     return this;
@@ -302,13 +307,6 @@ export class ComputeExpActionReq {
 export abstract class ComputeExpActionReqFactory {
   abstract create(data: unknown): ComputeExpActionReq;
 }
-type PartialDeep<T> = {
-  [P in keyof T]?: T[P] extends Array<infer U>
-    ? Array<PartialDeep<U>>
-    : T[P] extends object
-      ? PartialDeep<T[P]>
-      : T[P];
-};
 /**
  * The base type definition for computeExpActionReq
  **/
@@ -346,7 +344,9 @@ export class ComputeExpActionRes {
    *
    * @type {big.Int}
    **/
-  set result(value: big.Int) {}
+  set result(value: big.Int) {
+    this.#result = value;
+  }
   setResult(value: big.Int) {
     this.result = value;
     return this;
@@ -436,13 +436,6 @@ export class ComputeExpActionRes {
 export abstract class ComputeExpActionResFactory {
   abstract create(data: unknown): ComputeExpActionRes;
 }
-type PartialDeep<T> = {
-  [P in keyof T]?: T[P] extends Array<infer U>
-    ? Array<PartialDeep<U>>
-    : T[P] extends object
-      ? PartialDeep<T[P]>
-      : T[P];
-};
 /**
  * The base type definition for computeExpActionRes
  **/

--- a/examples/fullstack/client-ts/EnvelopeExampleAction.ts
+++ b/examples/fullstack/client-ts/EnvelopeExampleAction.ts
@@ -1,12 +1,13 @@
+import { GResponse } from "./sdk/envelopes/index";
+import { buildUrl } from "./sdk/common/buildUrl";
 import {
-  FetchxContext,
   fetchx,
   handleFetchResponse,
+  type FetchxContext,
+  type PartialDeep,
   type TypedRequestInit,
   type TypedResponse,
 } from "./sdk/common/fetchx";
-import { GResponse } from "./sdk/envelopes/index";
-import { buildUrl } from "./sdk/common/buildUrl";
 import {
   type UseMutationOptions,
   type UseQueryOptions,
@@ -315,13 +316,6 @@ export class EnvelopeExampleActionRes {
 export abstract class EnvelopeExampleActionResFactory {
   abstract create(data: unknown): EnvelopeExampleActionRes;
 }
-type PartialDeep<T> = {
-  [P in keyof T]?: T[P] extends Array<infer U>
-    ? Array<PartialDeep<U>>
-    : T[P] extends object
-      ? PartialDeep<T[P]>
-      : T[P];
-};
 /**
  * The base type definition for envelopeExampleActionRes
  **/

--- a/examples/fullstack/client-ts/sdk/common/fetchx.ts
+++ b/examples/fullstack/client-ts/sdk/common/fetchx.ts
@@ -187,3 +187,10 @@ export class FetchxContext {
     );
   }
 }
+export type PartialDeep<T> = {
+  [P in keyof T]?: T[P] extends Array<infer U>
+    ? Array<PartialDeep<U>>
+    : T[P] extends object
+      ? PartialDeep<T[P]>
+      : T[P];
+};

--- a/examples/fullstack/client/AllDataAction.js
+++ b/examples/fullstack/client/AllDataAction.js
@@ -1,0 +1,238 @@
+import { CommonVectorResponseDto } from "./CommonVectorResponseDto";
+import { buildUrl } from "./sdk/common/buildUrl";
+import { fetchx, handleFetchResponse } from "./sdk/common/fetchx";
+import { withPrefix } from "./sdk/common/withPrefix";
+/**
+ * Action to communicate with the action allData
+ */
+/**
+ * AllDataAction
+ */
+export class AllDataAction {
+  //
+  static URL = "/res/22";
+  static NewUrl = (qs) => buildUrl(AllDataAction.URL, undefined, qs);
+  static Method = "";
+  static Fetch$ = async (qs, ctx, init, overrideUrl) => {
+    return fetchx(
+      overrideUrl ?? AllDataAction.NewUrl(qs),
+      {
+        method: AllDataAction.Method,
+        ...(init || {}),
+      },
+      ctx,
+    );
+  };
+  static Fetch = async (
+    init,
+    { creatorFn, qs, ctx, onMessage, overrideUrl } = {
+      creatorFn: (item) => new AllDataActionRes(item),
+    },
+  ) => {
+    creatorFn = creatorFn || ((item) => new AllDataActionRes(item));
+    const res = await AllDataAction.Fetch$(qs, ctx, init, overrideUrl);
+    return handleFetchResponse(
+      res,
+      (item) => (creatorFn ? creatorFn(item) : item),
+      onMessage,
+      init?.signal,
+    );
+  };
+  static Definition = {
+    name: "allData",
+    url: "/res/22",
+    out: {
+      fields: [
+        {
+          name: "stringType",
+          type: "string",
+        },
+        {
+          name: "stringTypeNull",
+          type: "string?",
+        },
+        {
+          name: "collection",
+          type: "collection",
+          target: "CommonVectorResponseDto",
+        },
+      ],
+    },
+  };
+}
+/**
+ * The base class definition for allDataActionRes
+ **/
+export class AllDataActionRes {
+  /**
+   *
+   * @type {string}
+   **/
+  #stringType = "";
+  /**
+   *
+   * @returns {string}
+   **/
+  get stringType() {
+    return this.#stringType;
+  }
+  /**
+   *
+   * @type {string}
+   **/
+  set stringType(value) {
+    this.#stringType = String(value);
+  }
+  setStringType(value) {
+    this.stringType = value;
+    return this;
+  }
+  /**
+   *
+   * @type {string}
+   **/
+  #stringTypeNull = undefined;
+  /**
+   *
+   * @returns {string}
+   **/
+  get stringTypeNull() {
+    return this.#stringTypeNull;
+  }
+  /**
+   *
+   * @type {string}
+   **/
+  set stringTypeNull(value) {
+    const correctType =
+      typeof value === "string" || value === undefined || value === null;
+    this.#stringTypeNull = correctType ? value : String(value);
+  }
+  setStringTypeNull(value) {
+    this.stringTypeNull = value;
+    return this;
+  }
+  /**
+   *
+   * @type {CommonVectorResponseDto[]}
+   **/
+  #collection = [];
+  /**
+   *
+   * @returns {CommonVectorResponseDto[]}
+   **/
+  get collection() {
+    return this.#collection;
+  }
+  /**
+   *
+   * @type {CommonVectorResponseDto[]}
+   **/
+  set collection(value) {
+    // For arrays, you only can pass arrays to the object
+    if (!Array.isArray(value)) {
+      return;
+    }
+    if (value.length > 0 && value[0] instanceof CommonVectorResponseDto) {
+      this.#collection = value;
+    } else {
+      this.#collection = value.map((item) => new CommonVectorResponseDto(item));
+    }
+  }
+  setCollection(value) {
+    this.collection = value;
+    return this;
+  }
+  constructor(data) {
+    if (data === null || data === undefined) {
+      return;
+    }
+    if (typeof data === "string") {
+      this.applyFromObject(JSON.parse(data));
+    } else if (this.#isJsonAppliable(data)) {
+      this.applyFromObject(data);
+    } else {
+      throw new Error(
+        "Instance cannot be created on an unknown value, check the content being passed. got: " +
+          typeof data,
+      );
+    }
+  }
+  #isJsonAppliable(obj) {
+    const g = globalThis;
+    const isBuffer =
+      typeof g.Buffer !== "undefined" &&
+      typeof g.Buffer.isBuffer === "function" &&
+      g.Buffer.isBuffer(obj);
+    const isBlob = typeof g.Blob !== "undefined" && obj instanceof g.Blob;
+    return (
+      obj &&
+      typeof obj === "object" &&
+      !Array.isArray(obj) &&
+      !isBuffer &&
+      !(obj instanceof ArrayBuffer) &&
+      !isBlob
+    );
+  }
+  /**
+   * casts the fields of a javascript object into the class properties one by one
+   **/
+  applyFromObject(data = {}) {
+    const d = data;
+    if (d.stringType !== undefined) {
+      this.stringType = d.stringType;
+    }
+    if (d.stringTypeNull !== undefined) {
+      this.stringTypeNull = d.stringTypeNull;
+    }
+    if (d.collection !== undefined) {
+      this.collection = d.collection;
+    }
+  }
+  /**
+   *	Special toJSON override, since the field are private,
+   *	Json stringify won't see them unless we mention it explicitly.
+   **/
+  toJSON() {
+    return {
+      stringType: this.#stringType,
+      stringTypeNull: this.#stringTypeNull,
+      collection: this.#collection,
+    };
+  }
+  toString() {
+    return JSON.stringify(this);
+  }
+  static get Fields() {
+    return {
+      stringType: "stringType",
+      stringTypeNull: "stringTypeNull",
+      collection$: "collection",
+      get collection() {
+        return withPrefix("collection[:i]", CommonVectorResponseDto.Fields);
+      },
+    };
+  }
+  /**
+   * Creates an instance of AllDataActionRes, and possibleDtoObject
+   * needs to satisfy the type requirement fully, otherwise typescript compile would
+   * be complaining.
+   **/
+  static from(possibleDtoObject) {
+    return new AllDataActionRes(possibleDtoObject);
+  }
+  /**
+   * Creates an instance of AllDataActionRes, and partialDtoObject
+   * needs to satisfy the type, but partially, and rest of the content would
+   * be constructed according to data types and nullability.
+   **/
+  static with(partialDtoObject) {
+    return new AllDataActionRes(partialDtoObject);
+  }
+  copyWith(partial) {
+    return new AllDataActionRes({ ...this.toJSON(), ...partial });
+  }
+  clone() {
+    return new AllDataActionRes(this.toJSON());
+  }
+}

--- a/examples/fullstack/client/CommonVectorComputeDto.js
+++ b/examples/fullstack/client/CommonVectorComputeDto.js
@@ -19,7 +19,9 @@ export class CommonVectorComputeDto {
    *
    * @type {number[]}
    **/
-  set initialVector1(value) {}
+  set initialVector1(value) {
+    this.#initialVector1 = value;
+  }
   setInitialVector1(value) {
     this.initialVector1 = value;
     return this;
@@ -88,7 +90,9 @@ export class CommonVectorComputeDto {
    *
    * @type {number[]}
    **/
-  set initialVector2(value) {}
+  set initialVector2(value) {
+    this.#initialVector2 = value;
+  }
   setInitialVector2(value) {
     this.initialVector2 = value;
     return this;
@@ -145,7 +149,9 @@ export class CommonVectorComputeDto {
    *
    * @type {string[]}
    **/
-  set fieldTypeSlice(value) {}
+  set fieldTypeSlice(value) {
+    this.#fieldTypeSlice = value;
+  }
   setFieldTypeSlice(value) {
     this.fieldTypeSlice = value;
     return this;
@@ -221,7 +227,9 @@ export class CommonVectorComputeDto {
    *
    * @type {Money}
    **/
-  set complexMoney(value) {}
+  set complexMoney(value) {
+    this.#complexMoney = value;
+  }
   setComplexMoney(value) {
     this.complexMoney = value;
     return this;

--- a/examples/fullstack/client/CommonVectorResponseDto.js
+++ b/examples/fullstack/client/CommonVectorResponseDto.js
@@ -20,7 +20,9 @@ export class CommonVectorResponseDto {
    *
    * @type {number[]}
    **/
-  set outputVector(value) {}
+  set outputVector(value) {
+    this.#outputVector = value;
+  }
   setOutputVector(value) {
     this.outputVector = value;
     return this;

--- a/examples/fullstack/client/ComputeApiAction.js
+++ b/examples/fullstack/client/ComputeApiAction.js
@@ -1,10 +1,6 @@
-import {
-  FetchxContext,
-  fetchx,
-  handleFetchResponse,
-} from "./sdk/common/fetchx";
 import { URLSearchParamsX } from "./sdk/common/URLSearchParamsX";
 import { buildUrl } from "./sdk/common/buildUrl";
+import { fetchx, handleFetchResponse } from "./sdk/common/fetchx";
 /**
  * Action to communicate with the action computeApi
  */
@@ -36,7 +32,7 @@ export class ComputeApiAction {
     const res = await ComputeApiAction.Fetch$(qs, ctx, init, overrideUrl);
     return handleFetchResponse(
       res,
-      (item) => creatorFn(item),
+      (item) => (creatorFn ? creatorFn(item) : item),
       onMessage,
       init?.signal,
     );
@@ -106,7 +102,9 @@ export class ComputeApiActionReq {
    *
    * @type {number[]}
    **/
-  set initialVector1(value) {}
+  set initialVector1(value) {
+    this.#initialVector1 = value;
+  }
   setInitialVector1(value) {
     this.initialVector1 = value;
     return this;
@@ -152,7 +150,9 @@ export class ComputeApiActionReq {
    *
    * @type {number[]}
    **/
-  set initialVector2(value) {}
+  set initialVector2(value) {
+    this.#initialVector2 = value;
+  }
   setInitialVector2(value) {
     this.initialVector2 = value;
     return this;
@@ -273,7 +273,9 @@ export class ComputeApiActionRes {
    *
    * @type {number[]}
    **/
-  set outputVector(value) {}
+  set outputVector(value) {
+    this.#outputVector = value;
+  }
   setOutputVector(value) {
     this.outputVector = value;
     return this;

--- a/examples/fullstack/client/ComputeApiSseAction.js
+++ b/examples/fullstack/client/ComputeApiSseAction.js
@@ -1,9 +1,5 @@
-import {
-  FetchxContext,
-  fetchx,
-  handleFetchResponse,
-} from "./sdk/common/fetchx";
 import { buildUrl } from "./sdk/common/buildUrl";
+import { fetchx, handleFetchResponse } from "./sdk/common/fetchx";
 /**
  * Action to communicate with the action computeApiSse
  */
@@ -35,7 +31,7 @@ export class ComputeApiSseAction {
     const res = await ComputeApiSseAction.Fetch$(qs, ctx, init, overrideUrl);
     return handleFetchResponse(
       res,
-      (item) => creatorFn(item),
+      (item) => (creatorFn ? creatorFn(item) : item),
       onMessage,
       init?.signal,
     );
@@ -95,7 +91,9 @@ export class ComputeApiSseActionReq {
    *
    * @type {number[]}
    **/
-  set initialVector1(value) {}
+  set initialVector1(value) {
+    this.#initialVector1 = value;
+  }
   setInitialVector1(value) {
     this.initialVector1 = value;
     return this;
@@ -141,7 +139,9 @@ export class ComputeApiSseActionReq {
    *
    * @type {number[]}
    **/
-  set initialVector2(value) {}
+  set initialVector2(value) {
+    this.#initialVector2 = value;
+  }
   setInitialVector2(value) {
     this.initialVector2 = value;
     return this;
@@ -262,7 +262,9 @@ export class ComputeApiSseActionRes {
    *
    * @type {number[]}
    **/
-  set outputVector(value) {}
+  set outputVector(value) {
+    this.#outputVector = value;
+  }
   setOutputVector(value) {
     this.outputVector = value;
     return this;

--- a/examples/fullstack/client/ComputeApiSseChannelAction.js
+++ b/examples/fullstack/client/ComputeApiSseChannelAction.js
@@ -1,9 +1,5 @@
-import {
-  FetchxContext,
-  fetchx,
-  handleFetchResponse,
-} from "./sdk/common/fetchx";
 import { buildUrl } from "./sdk/common/buildUrl";
+import { fetchx, handleFetchResponse } from "./sdk/common/fetchx";
 /**
  * Action to communicate with the action computeApiSseChannel
  */
@@ -42,7 +38,7 @@ export class ComputeApiSseChannelAction {
     );
     return handleFetchResponse(
       res,
-      (item) => creatorFn(item),
+      (item) => (creatorFn ? creatorFn(item) : item),
       onMessage,
       init?.signal,
     );
@@ -102,7 +98,9 @@ export class ComputeApiSseChannelActionReq {
    *
    * @type {number[]}
    **/
-  set initialVector1(value) {}
+  set initialVector1(value) {
+    this.#initialVector1 = value;
+  }
   setInitialVector1(value) {
     this.initialVector1 = value;
     return this;
@@ -148,7 +146,9 @@ export class ComputeApiSseChannelActionReq {
    *
    * @type {number[]}
    **/
-  set initialVector2(value) {}
+  set initialVector2(value) {
+    this.#initialVector2 = value;
+  }
   setInitialVector2(value) {
     this.initialVector2 = value;
     return this;
@@ -269,7 +269,9 @@ export class ComputeApiSseChannelActionRes {
    *
    * @type {number[]}
    **/
-  set outputVector(value) {}
+  set outputVector(value) {
+    this.#outputVector = value;
+  }
   setOutputVector(value) {
     this.outputVector = value;
     return this;

--- a/examples/fullstack/client/ComputeExpAction.js
+++ b/examples/fullstack/client/ComputeExpAction.js
@@ -1,9 +1,5 @@
-import {
-  FetchxContext,
-  fetchx,
-  handleFetchResponse,
-} from "./sdk/common/fetchx";
 import { buildUrl } from "./sdk/common/buildUrl";
+import { fetchx, handleFetchResponse } from "./sdk/common/fetchx";
 /**
  * Action to communicate with the action computeExp
  */
@@ -42,7 +38,7 @@ export class ComputeExpAction {
     );
     return handleFetchResponse(
       res,
-      (item) => creatorFn(item),
+      (item) => (creatorFn ? creatorFn(item) : item),
       onMessage,
       init?.signal,
     );
@@ -96,7 +92,9 @@ export class ComputeExpActionReq {
    *
    * @type {Int}
    **/
-  set base(value) {}
+  set base(value) {
+    this.#base = value;
+  }
   setBase(value) {
     this.base = value;
     return this;
@@ -117,7 +115,9 @@ export class ComputeExpActionReq {
    *
    * @type {Int}
    **/
-  set exponent(value) {}
+  set exponent(value) {
+    this.#exponent = value;
+  }
   setExponent(value) {
     this.exponent = value;
     return this;
@@ -227,7 +227,9 @@ export class ComputeExpActionRes {
    *
    * @type {big.Int}
    **/
-  set result(value) {}
+  set result(value) {
+    this.#result = value;
+  }
   setResult(value) {
     this.result = value;
     return this;

--- a/examples/fullstack/client/EnvelopeExampleAction.js
+++ b/examples/fullstack/client/EnvelopeExampleAction.js
@@ -1,10 +1,6 @@
-import {
-  FetchxContext,
-  fetchx,
-  handleFetchResponse,
-} from "./sdk/common/fetchx";
 import { GResponse } from "./sdk/envelopes/index";
 import { buildUrl } from "./sdk/common/buildUrl";
+import { fetchx, handleFetchResponse } from "./sdk/common/fetchx";
 /**
  * Action to communicate with the action envelopeExample
  */

--- a/examples/fullstack/client/sdk/common/WebSocketX.ts
+++ b/examples/fullstack/client/sdk/common/WebSocketX.ts
@@ -12,7 +12,7 @@ export class WebSocketX<
     url: string | URL,
     protocols?: string | string[],
     options?: {
-      MessageFactoryClass: ConstructorWithArg<any>;
+      MessageFactoryClass?: ConstructorWithArg<any>;
     }
   ) {
     super(url, protocols);

--- a/examples/fullstack/client/sdk/common/fetchx.ts
+++ b/examples/fullstack/client/sdk/common/fetchx.ts
@@ -187,7 +187,6 @@ export class FetchxContext {
     );
   }
 }
-
 export type PartialDeep<T> = {
   [P in keyof T]?: T[P] extends Array<infer U>
     ? Array<PartialDeep<U>>

--- a/examples/fullstack/client/sdk/envelopes/google-json-style-guide/index.ts
+++ b/examples/fullstack/client/sdk/envelopes/google-json-style-guide/index.ts
@@ -1,6 +1,5 @@
 import type { CreatorSignature, EnvelopeClass } from "../common/EnvelopeClass";
 import { ResponseDto } from "./generated/ResponseDto";
-
 // Use this class to generate a GResponse.
 export class GResponse<T> extends ResponseDto<T> implements EnvelopeClass<T> {
   creator?: CreatorSignature<T> | null;

--- a/examples/fullstack/cmd/main.go
+++ b/examples/fullstack/cmd/main.go
@@ -156,32 +156,6 @@ func runServer(addr string) error {
 		return msg.Conn.WriteMessage(websocket.TextMessage, resBytes)
 	})
 
-	// ----------- WebSocket (duplex channel) -----------
-	unk.ComputeReactiveActionDuplex(r, func(ctx *unk.ComputeReactiveActionSession) {
-
-		fmt.Println(ctx.PathParams.Age + ctx.PathParams.Id)
-
-		ctx.Out <- unk.ComputeReactiveActionMessage{
-			MessageType: websocket.TextMessage,
-			Raw:         []byte(fmt.Sprintf("Query Param 1: %v", ctx.QueryParams.QueryParam1)),
-		}
-
-		for {
-			select {
-			case msg, ok := <-ctx.In:
-				if !ok {
-					return
-				}
-				ctx.Out <- unk.ComputeReactiveActionMessage{
-					MessageType: websocket.TextMessage,
-					Raw:         msg.Raw,
-				}
-			case <-ctx.Done:
-				return
-			}
-		}
-	})
-
 	fmt.Println("Server running on", addr)
 	return r.Run(addr)
 }

--- a/examples/fullstack/definitions.emi.yml
+++ b/examples/fullstack/definitions.emi.yml
@@ -30,8 +30,8 @@ dtos:
           - name: arrayField2
             type: array
             fields:
-            - name: lastItem
-              type: string
+              - name: lastItem
+                type: string
       - name: fieldTypeSlice
         type: slice
         primitive: string
@@ -53,6 +53,18 @@ dtos:
 
 actions:
 
+  - name: allData
+    url: /res/22
+    out:
+      fields:
+        - name: stringType
+          type: string
+        - name: stringTypeNull
+          type: string?
+        - name: collection
+          type: collection
+          target: CommonVectorResponseDto
+
   - name: envelopeExample
     url: /response/with/envelop
     method: get
@@ -61,26 +73,25 @@ actions:
       fields:
         - name: content
           type: string
-      
+
   - name: computeExp
     description: Computes the exp value using big integer
     url: /big/exp/:first/:second
     in:
       fields:
-      - name: base
-        type: complex
-        complex: Int
-      - name: exponent
-        type: complex
-        complex: Int
+        - name: base
+          type: complex
+          complex: Int
+        - name: exponent
+          type: complex
+          complex: Int
     out:
       fields:
         - name: result
           type: complex
           complex: big.Int
   - name: computeReactive
-    description:
-      Reactive compute elsasements.
+    description: Reactive compute elsasements.
     method: reactive
     url: /compute/reactive/:id int32/:age int32
     qs:
@@ -107,8 +118,7 @@ actions:
             type: slice
             primitive: float64
   - name: computeReactiveNoPath
-    description:
-      Reactive compute elsasements.
+    description: Reactive compute elsasements.
     method: reactive
     url: /compute/reactive
     qs:
@@ -116,10 +126,9 @@ actions:
         type: string
       - name: securityToken
         type: string
-        
+
   - name: computeApiSseChannel
-    description: 
-      We use a helper in order to send SSE, instead of pure code in gin.
+    description: We use a helper in order to send SSE, instead of pure code in gin.
     method: get
     url: /compute/sse/ch
     in:
@@ -138,8 +147,7 @@ actions:
           type: slice
           primitive: int
   - name: computeApiSse
-    description: 
-      The same compute api, but it would return the response as SSE.
+    description: The same compute api, but it would return the response as SSE.
     method: get
     url: /compute/sse
     in:
@@ -183,4 +191,3 @@ actions:
         - name: outputVector
           type: slice
           primitive: int
-      

--- a/examples/fullstack/sdk/AllDataAction.go
+++ b/examples/fullstack/sdk/AllDataAction.go
@@ -12,9 +12,9 @@ import (
 )
 
 /**
-* Action to communicate with the action EnvelopeExampleAction
+* Action to communicate with the action AllDataAction
  */
-func EnvelopeExampleActionMeta() struct {
+func AllDataActionMeta() struct {
 	Name        string
 	CliName     string
 	URL         string
@@ -28,35 +28,48 @@ func EnvelopeExampleActionMeta() struct {
 		Method      string
 		Description string
 	}{
-		Name:        "EnvelopeExampleAction",
-		CliName:     "envelope-example-action",
-		URL:         "/response/with/envelop",
-		Method:      "GET",
+		Name:        "AllDataAction",
+		CliName:     "all-data-action",
+		URL:         "/res/22",
+		Method:      "",
 		Description: ``,
 	}
 }
-func GetEnvelopeExampleActionResCliFlags(prefix string) []emigo.CliFlag {
+func GetAllDataActionResCliFlags(prefix string) []emigo.CliFlag {
 	return []emigo.CliFlag{
 		{
-			Name: prefix + "content",
+			Name: prefix + "string-type",
 			Type: "string",
+		},
+		{
+			Name: prefix + "string-type-null",
+			Type: "string?",
+		},
+		{
+			Name: prefix + "collection",
+			Type: "collection",
 		},
 	}
 }
-func CastEnvelopeExampleActionResFromCli(c emigo.CliCastable) EnvelopeExampleActionRes {
-	data := EnvelopeExampleActionRes{}
-	if c.IsSet("content") {
-		data.Content = c.String("content")
+func CastAllDataActionResFromCli(c emigo.CliCastable) AllDataActionRes {
+	data := AllDataActionRes{}
+	if c.IsSet("string-type") {
+		data.StringType = c.String("string-type")
+	}
+	if c.IsSet("string-type-null") {
+		emigo.ParseNullable(c.String("string-type-null"), &data.StringTypeNull)
 	}
 	return data
 }
 
-// The base class definition for envelopeExampleActionRes
-type EnvelopeExampleActionRes struct {
-	Content string `json:"content" yaml:"content"`
+// The base class definition for allDataActionRes
+type AllDataActionRes struct {
+	StringType     string                    `json:"stringType" yaml:"stringType"`
+	StringTypeNull emigo.Nullable[string]    `json:"stringTypeNull" yaml:"stringTypeNull"`
+	Collection     []CommonVectorResponseDto `json:"collection" yaml:"collection"`
 }
 
-func (x *EnvelopeExampleActionRes) Json() string {
+func (x *AllDataActionRes) Json() string {
 	if x != nil {
 		str, _ := json.MarshalIndent(x, "", "  ")
 		return string(str)
@@ -64,68 +77,68 @@ func (x *EnvelopeExampleActionRes) Json() string {
 	return ""
 }
 
-type EnvelopeExampleActionResponse struct {
+type AllDataActionResponse struct {
 	StatusCode int
 	Headers    map[string]string
 	Payload    interface{}
 }
 
-func (x *EnvelopeExampleActionResponse) SetContentType(contentType string) *EnvelopeExampleActionResponse {
+func (x *AllDataActionResponse) SetContentType(contentType string) *AllDataActionResponse {
 	if x.Headers == nil {
 		x.Headers = make(map[string]string)
 	}
 	x.Headers["Content-Type"] = contentType
 	return x
 }
-func (x *EnvelopeExampleActionResponse) AsStream(r io.Reader, contentType string) *EnvelopeExampleActionResponse {
+func (x *AllDataActionResponse) AsStream(r io.Reader, contentType string) *AllDataActionResponse {
 	x.Payload = r
 	x.SetContentType(contentType)
 	return x
 }
-func (x *EnvelopeExampleActionResponse) AsJSON(payload any) *EnvelopeExampleActionResponse {
+func (x *AllDataActionResponse) AsJSON(payload any) *AllDataActionResponse {
 	x.Payload = payload
 	x.SetContentType("application/json")
 	return x
 }
-func (x *EnvelopeExampleActionResponse) AsHTML(payload string) *EnvelopeExampleActionResponse {
+func (x *AllDataActionResponse) AsHTML(payload string) *AllDataActionResponse {
 	x.Payload = payload
 	x.SetContentType("text/html; charset=utf-8")
 	return x
 }
-func (x *EnvelopeExampleActionResponse) AsBytes(payload []byte) *EnvelopeExampleActionResponse {
+func (x *AllDataActionResponse) AsBytes(payload []byte) *AllDataActionResponse {
 	x.Payload = payload
 	x.SetContentType("application/octet-stream")
 	return x
 }
-func (x EnvelopeExampleActionResponse) GetStatusCode() int {
+func (x AllDataActionResponse) GetStatusCode() int {
 	return x.StatusCode
 }
-func (x EnvelopeExampleActionResponse) GetRespHeaders() map[string]string {
+func (x AllDataActionResponse) GetRespHeaders() map[string]string {
 	return x.Headers
 }
-func (x EnvelopeExampleActionResponse) GetPayload() interface{} {
+func (x AllDataActionResponse) GetPayload() interface{} {
 	return x.Payload
 }
 
-// EnvelopeExampleActionRaw registers a raw Gin route for the EnvelopeExampleAction action.
+// AllDataActionRaw registers a raw Gin route for the AllDataAction action.
 // This gives the developer full control over middleware, handlers, and response handling.
-func EnvelopeExampleActionRaw(r *gin.Engine, handlers ...gin.HandlerFunc) {
-	meta := EnvelopeExampleActionMeta()
+func AllDataActionRaw(r *gin.Engine, handlers ...gin.HandlerFunc) {
+	meta := AllDataActionMeta()
 	r.Handle(meta.Method, meta.URL, handlers...)
 }
 
-type EnvelopeExampleActionRequestSig = func(c EnvelopeExampleActionRequest) (*EnvelopeExampleActionResponse, error)
+type AllDataActionRequestSig = func(c AllDataActionRequest) (*AllDataActionResponse, error)
 
-// EnvelopeExampleActionHandler returns the HTTP method, route URL, and a typed Gin handler for the EnvelopeExampleAction action.
+// AllDataActionHandler returns the HTTP method, route URL, and a typed Gin handler for the AllDataAction action.
 // Developers implement their business logic as a function that receives a typed request object
 // and returns either an *ActionResponse or nil. JSON marshalling, headers, and errors are handled automatically.
-func EnvelopeExampleActionHandler(
-	handler EnvelopeExampleActionRequestSig,
+func AllDataActionHandler(
+	handler AllDataActionRequestSig,
 ) (method, url string, h gin.HandlerFunc) {
-	meta := EnvelopeExampleActionMeta()
+	meta := AllDataActionMeta()
 	return meta.Method, meta.URL, func(m *gin.Context) {
 		// Build typed request wrapper
-		req := EnvelopeExampleActionRequest{
+		req := AllDataActionRequest{
 			Body:        nil,
 			QueryParams: m.Request.URL.Query(),
 			Headers:     m.Request.Header,
@@ -157,26 +170,26 @@ func EnvelopeExampleActionHandler(
 	}
 }
 
-// EnvelopeExampleAction is a high-level convenience wrapper around EnvelopeExampleActionHandler.
+// AllDataAction is a high-level convenience wrapper around AllDataActionHandler.
 // It automatically constructs and registers the typed route on the Gin engine.
 // Use this when you don't need custom middleware or route grouping.
-func EnvelopeExampleActionGin(r gin.IRoutes, handler EnvelopeExampleActionRequestSig) {
-	method, url, h := EnvelopeExampleActionHandler(handler)
+func AllDataActionGin(r gin.IRoutes, handler AllDataActionRequestSig) {
+	method, url, h := AllDataActionHandler(handler)
 	r.Handle(method, url, h)
 }
 
 /**
- * Query parameters for EnvelopeExampleAction
+ * Query parameters for AllDataAction
  */
 // Query wrapper with private fields
-type EnvelopeExampleActionQuery struct {
+type AllDataActionQuery struct {
 	values url.Values
 	mapped map[string]interface{}
 	// Typesafe fields
 }
 
-func EnvelopeExampleActionQueryFromString(rawQuery string) EnvelopeExampleActionQuery {
-	v := EnvelopeExampleActionQuery{}
+func AllDataActionQueryFromString(rawQuery string) AllDataActionQuery {
+	v := AllDataActionQuery{}
 	values, _ := url.ParseQuery(rawQuery)
 	mapped := map[string]interface{}{}
 	if result, err := emigo.UnmarshalQs(rawQuery); err == nil {
@@ -194,44 +207,44 @@ func EnvelopeExampleActionQueryFromString(rawQuery string) EnvelopeExampleAction
 	v.mapped = mapped
 	return v
 }
-func EnvelopeExampleActionQueryFromGin(c *gin.Context) EnvelopeExampleActionQuery {
-	return EnvelopeExampleActionQueryFromString(c.Request.URL.RawQuery)
+func AllDataActionQueryFromGin(c *gin.Context) AllDataActionQuery {
+	return AllDataActionQueryFromString(c.Request.URL.RawQuery)
 }
-func EnvelopeExampleActionQueryFromHttp(r *http.Request) EnvelopeExampleActionQuery {
-	return EnvelopeExampleActionQueryFromString(r.URL.RawQuery)
+func AllDataActionQueryFromHttp(r *http.Request) AllDataActionQuery {
+	return AllDataActionQueryFromString(r.URL.RawQuery)
 }
-func (q EnvelopeExampleActionQuery) Values() url.Values {
+func (q AllDataActionQuery) Values() url.Values {
 	return q.values
 }
-func (q EnvelopeExampleActionQuery) Mapped() map[string]interface{} {
+func (q AllDataActionQuery) Mapped() map[string]interface{} {
 	return q.mapped
 }
-func (q *EnvelopeExampleActionQuery) SetValues(v url.Values) {
+func (q *AllDataActionQuery) SetValues(v url.Values) {
 	q.values = v
 }
-func (q *EnvelopeExampleActionQuery) SetMapped(m map[string]interface{}) {
+func (q *AllDataActionQuery) SetMapped(m map[string]interface{}) {
 	q.mapped = m
 }
 
-type EnvelopeExampleActionRequest struct {
+type AllDataActionRequest struct {
 	Body        interface{}
 	QueryParams url.Values
 	Headers     http.Header
 	GinCtx      *gin.Context
 	CliCtx      *cli.Context
 }
-type EnvelopeExampleActionResult struct {
+type AllDataActionResult struct {
 	resp    *http.Response // embed original response
 	Payload interface{}
 }
 
-func EnvelopeExampleActionCall(
-	req EnvelopeExampleActionRequest,
+func AllDataActionCall(
+	req AllDataActionRequest,
 	config *emigo.APIClient, // optional pre-built request
-) (*EnvelopeExampleActionResult, error) {
+) (*AllDataActionResult, error) {
 	var httpReq *http.Request
 	if config == nil || config.Httpr == nil {
-		meta := EnvelopeExampleActionMeta()
+		meta := AllDataActionMeta()
 		baseURL := meta.URL
 		// Build final URL with query string
 		u, err := url.Parse(baseURL)
@@ -255,7 +268,7 @@ func EnvelopeExampleActionCall(
 	if err != nil {
 		return nil, err
 	}
-	var result EnvelopeExampleActionResult
+	var result AllDataActionResult
 	result.resp = resp
 	defer resp.Body.Close()
 	respBody, err := io.ReadAll(resp.Body)

--- a/examples/fullstack/sdk/CommonVectorComputeDto.go
+++ b/examples/fullstack/sdk/CommonVectorComputeDto.go
@@ -85,7 +85,7 @@ func CastCommonVectorComputeDtoFromCli(c emigo.CliCastable) CommonVectorComputeD
 type CommonVectorComputeDto struct {
 	InitialVector1   []int                                  `json:"initialVector1" yaml:"initialVector1"`
 	Value            emigo.Nullable[string]                 `json:"value" yaml:"value"`
-	Valuex           string                                 `yaml:"valuex" json:"valuex"`
+	Valuex           string                                 `json:"valuex" yaml:"valuex"`
 	InitialVector2   []int                                  `json:"initialVector2" yaml:"initialVector2"`
 	FieldTypeArray   []CommonVectorComputeDtoFieldTypeArray `json:"fieldTypeArray" yaml:"fieldTypeArray"`
 	FieldTypeSlice   []string                               `json:"fieldTypeSlice" yaml:"fieldTypeSlice"`
@@ -119,7 +119,7 @@ func CastCommonVectorComputeDtoFieldTypeArrayFromCli(c emigo.CliCastable) Common
 
 // The base class definition for fieldTypeArray
 type CommonVectorComputeDtoFieldTypeArray struct {
-	ArrayField1 string                                            `yaml:"arrayField1" json:"arrayField1"`
+	ArrayField1 string                                            `json:"arrayField1" yaml:"arrayField1"`
 	ArrayField2 []CommonVectorComputeDtoFieldTypeArrayArrayField2 `json:"arrayField2" yaml:"arrayField2"`
 }
 

--- a/examples/fullstack/sdk/ComputeApiAction.go
+++ b/examples/fullstack/sdk/ComputeApiAction.go
@@ -115,6 +115,33 @@ type ComputeApiActionResponse struct {
 	Payload    interface{}
 }
 
+func (x *ComputeApiActionResponse) SetContentType(contentType string) *ComputeApiActionResponse {
+	if x.Headers == nil {
+		x.Headers = make(map[string]string)
+	}
+	x.Headers["Content-Type"] = contentType
+	return x
+}
+func (x *ComputeApiActionResponse) AsStream(r io.Reader, contentType string) *ComputeApiActionResponse {
+	x.Payload = r
+	x.SetContentType(contentType)
+	return x
+}
+func (x *ComputeApiActionResponse) AsJSON(payload any) *ComputeApiActionResponse {
+	x.Payload = payload
+	x.SetContentType("application/json")
+	return x
+}
+func (x *ComputeApiActionResponse) AsHTML(payload string) *ComputeApiActionResponse {
+	x.Payload = payload
+	x.SetContentType("text/html; charset=utf-8")
+	return x
+}
+func (x *ComputeApiActionResponse) AsBytes(payload []byte) *ComputeApiActionResponse {
+	x.Payload = payload
+	x.SetContentType("application/octet-stream")
+	return x
+}
 func (x ComputeApiActionResponse) GetStatusCode() int {
 	return x.StatusCode
 }

--- a/examples/fullstack/sdk/ComputeApiSseAction.go
+++ b/examples/fullstack/sdk/ComputeApiSseAction.go
@@ -115,6 +115,33 @@ type ComputeApiSseActionResponse struct {
 	Payload    interface{}
 }
 
+func (x *ComputeApiSseActionResponse) SetContentType(contentType string) *ComputeApiSseActionResponse {
+	if x.Headers == nil {
+		x.Headers = make(map[string]string)
+	}
+	x.Headers["Content-Type"] = contentType
+	return x
+}
+func (x *ComputeApiSseActionResponse) AsStream(r io.Reader, contentType string) *ComputeApiSseActionResponse {
+	x.Payload = r
+	x.SetContentType(contentType)
+	return x
+}
+func (x *ComputeApiSseActionResponse) AsJSON(payload any) *ComputeApiSseActionResponse {
+	x.Payload = payload
+	x.SetContentType("application/json")
+	return x
+}
+func (x *ComputeApiSseActionResponse) AsHTML(payload string) *ComputeApiSseActionResponse {
+	x.Payload = payload
+	x.SetContentType("text/html; charset=utf-8")
+	return x
+}
+func (x *ComputeApiSseActionResponse) AsBytes(payload []byte) *ComputeApiSseActionResponse {
+	x.Payload = payload
+	x.SetContentType("application/octet-stream")
+	return x
+}
 func (x ComputeApiSseActionResponse) GetStatusCode() int {
 	return x.StatusCode
 }

--- a/examples/fullstack/sdk/ComputeApiSseChannelAction.go
+++ b/examples/fullstack/sdk/ComputeApiSseChannelAction.go
@@ -68,7 +68,7 @@ func CastComputeApiSseChannelActionReqFromCli(c emigo.CliCastable) ComputeApiSse
 
 // The base class definition for computeApiSseChannelActionReq
 type ComputeApiSseChannelActionReq struct {
-	InitialVector1 []int                  `yaml:"initialVector1" json:"initialVector1"`
+	InitialVector1 []int                  `json:"initialVector1" yaml:"initialVector1"`
 	Value          emigo.Nullable[string] `json:"value" yaml:"value"`
 	InitialVector2 []int                  `json:"initialVector2" yaml:"initialVector2"`
 }
@@ -115,6 +115,33 @@ type ComputeApiSseChannelActionResponse struct {
 	Payload    interface{}
 }
 
+func (x *ComputeApiSseChannelActionResponse) SetContentType(contentType string) *ComputeApiSseChannelActionResponse {
+	if x.Headers == nil {
+		x.Headers = make(map[string]string)
+	}
+	x.Headers["Content-Type"] = contentType
+	return x
+}
+func (x *ComputeApiSseChannelActionResponse) AsStream(r io.Reader, contentType string) *ComputeApiSseChannelActionResponse {
+	x.Payload = r
+	x.SetContentType(contentType)
+	return x
+}
+func (x *ComputeApiSseChannelActionResponse) AsJSON(payload any) *ComputeApiSseChannelActionResponse {
+	x.Payload = payload
+	x.SetContentType("application/json")
+	return x
+}
+func (x *ComputeApiSseChannelActionResponse) AsHTML(payload string) *ComputeApiSseChannelActionResponse {
+	x.Payload = payload
+	x.SetContentType("text/html; charset=utf-8")
+	return x
+}
+func (x *ComputeApiSseChannelActionResponse) AsBytes(payload []byte) *ComputeApiSseChannelActionResponse {
+	x.Payload = payload
+	x.SetContentType("application/octet-stream")
+	return x
+}
 func (x ComputeApiSseChannelActionResponse) GetStatusCode() int {
 	return x.StatusCode
 }

--- a/examples/fullstack/sdk/ComputeExpAction.go
+++ b/examples/fullstack/sdk/ComputeExpAction.go
@@ -99,7 +99,7 @@ func CastComputeExpActionResFromCli(c emigo.CliCastable) ComputeExpActionRes {
 
 // The base class definition for computeExpActionRes
 type ComputeExpActionRes struct {
-	Result big.Int `yaml:"result" json:"result"`
+	Result big.Int `json:"result" yaml:"result"`
 }
 
 func (x *ComputeExpActionRes) Json() string {
@@ -116,6 +116,33 @@ type ComputeExpActionResponse struct {
 	Payload    interface{}
 }
 
+func (x *ComputeExpActionResponse) SetContentType(contentType string) *ComputeExpActionResponse {
+	if x.Headers == nil {
+		x.Headers = make(map[string]string)
+	}
+	x.Headers["Content-Type"] = contentType
+	return x
+}
+func (x *ComputeExpActionResponse) AsStream(r io.Reader, contentType string) *ComputeExpActionResponse {
+	x.Payload = r
+	x.SetContentType(contentType)
+	return x
+}
+func (x *ComputeExpActionResponse) AsJSON(payload any) *ComputeExpActionResponse {
+	x.Payload = payload
+	x.SetContentType("application/json")
+	return x
+}
+func (x *ComputeExpActionResponse) AsHTML(payload string) *ComputeExpActionResponse {
+	x.Payload = payload
+	x.SetContentType("text/html; charset=utf-8")
+	return x
+}
+func (x *ComputeExpActionResponse) AsBytes(payload []byte) *ComputeExpActionResponse {
+	x.Payload = payload
+	x.SetContentType("application/octet-stream")
+	return x
+}
 func (x ComputeExpActionResponse) GetStatusCode() int {
 	return x.StatusCode
 }

--- a/examples/fullstack/sdk/ComputeReactiveAction.go
+++ b/examples/fullstack/sdk/ComputeReactiveAction.go
@@ -9,24 +9,31 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
 /**
 * Action to communicate with the action ComputeReactiveAction
  */
 func ComputeReactiveActionMeta() struct {
-	Name   string
-	URL    string
-	Method string
+	Name        string
+	URL         string
+	Method      string
+	CliName     string
+	Description string
 } {
 	return struct {
-		Name   string
-		URL    string
-		Method string
+		Name        string
+		URL         string
+		Method      string
+		CliName     string
+		Description string
 	}{
-		Name:   "ComputeReactiveAction",
-		URL:    "/compute/reactive/:id/:age",
-		Method: "REACTIVE",
+		Name:        "ComputeReactiveAction",
+		URL:         "/compute/reactive/:id/:age",
+		Method:      "REACTIVE",
+		CliName:     "",
+		Description: "Reactive compute elsasements.",
 	}
 }
 
@@ -130,7 +137,6 @@ type ComputeReactiveActionMessage struct {
 	MessageType int
 	Error       error
 	PathParams  ComputeReactiveActionPathParameter
-	QueryParams ComputeReactiveActionQuery
 }
 
 // Developer handler type
@@ -156,7 +162,6 @@ func ComputeReactiveAction(r *gin.Engine, handler ComputeReactiveActionHandler) 
 				MessageType: mt,
 			}
 			msg.PathParams = pathParams
-			msg.QueryParams = ComputeReactiveActionQueryFromGin(c)
 			// Provide raw message to developer handler
 			if err := handler(msg); err != nil {
 				errMsg := fmt.Sprintf("handler error: %v", err)
@@ -169,102 +174,78 @@ func ComputeReactiveAction(r *gin.Engine, handler ComputeReactiveActionHandler) 
 }
 
 type ComputeReactiveActionSession struct {
-	In          <-chan ComputeReactiveActionMessage
-	Out         chan<- ComputeReactiveActionMessage
-	Done        <-chan struct{}
-	Close       func(err error)
-	PathParams  ComputeReactiveActionPathParameter
+	Ctx         *gin.Context
+	Socket      *websocket.Conn
+	Done        chan bool
+	Read        chan ComputeReactiveActionReadChan
 	QueryParams ComputeReactiveActionQuery
 }
 type ComputeReactiveActionHandlerDuplex func(*ComputeReactiveActionSession)
-
-// ComputeReactiveActionDuplex upgrades the HTTP connection to a WebSocket and
-// exposes it as a full-duplex, blocking session.
-//
-// The provided handler owns the lifetime of the connection.
-// The WebSocket remains open as long as the handler is running.
-// Returning from the handler will close the connection.
-//
-// Session channels:
-//   - ctx.In   : incoming messages from the client (closed on disconnect)
-//   - ctx.Out  : outgoing messages to the client (blocking send)
-//   - ctx.Done : closed when the server terminates the session
-//
-// Usage pattern:
-//
-//	external.ComputeReactiveActionDuplex(r, func(ctx *external.ComputeReactiveActionSession) {
-//		for {
-//			select {
-//			case msg, ok := <-ctx.In:
-//				if !ok {
-//					return // client disconnected
-//				}
-//				ctx.Out <- external.ComputeReactiveActionMessage{
-//					MessageType: websocket.TextMessage,
-//					Raw:         msg.Raw,
-//				}
-//
-//			case <-ctx.Done:
-//				return // server-side close
-//			}
-//		}
-//	})
-//
-// Important:
-//   - Always read the generated code, don't use blindly.
-//   - If there is an error on write, you'll get a message back, with message type -1 (instead of default websocket message type int.)
-//   - The handler MUST block (typically via a loop).
-//   - Returning from the handler closes the WebSocket.
-//   - Do not treat this as a per-message callback.
-func ComputeReactiveActionDuplex(r *gin.Engine, handler ComputeReactiveActionHandlerDuplex) {
-	meta := ComputeReactiveActionMeta()
-	// The actual callback is extracted, in case you need to handle multiple handlers or customize, use it directly.
-	r.GET(meta.URL, func(ctx *gin.Context) {
-		ComputeReactiveActionDuplexGinHandler(ctx, handler)
-	})
+type ComputeReactiveActionReadChan struct {
+	Data  []byte
+	Error error
 }
-func ComputeReactiveActionDuplexGinHandler(c *gin.Context, handler ComputeReactiveActionHandlerDuplex) {
-	pathParams := ComputeReactiveActionPathParameterFromGin(c)
-	ws, err := upgraderComputeReactiveAction.Upgrade(c.Writer, c.Request, nil)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "cannot upgrade websocket"})
-		return
-	}
-	in := make(chan ComputeReactiveActionMessage)
-	out := make(chan ComputeReactiveActionMessage)
-	done := make(chan struct{})
-	session := &ComputeReactiveActionSession{
-		In:   in,
-		Out:  out,
-		Done: done,
-		Close: func(err error) {
-			close(done)
-			ws.Close()
-		},
-	}
-	session.PathParams = pathParams
-	session.QueryParams = ComputeReactiveActionQueryFromGin(c)
-	// Read loop
-	go func() {
-		defer close(in)
-		for {
-			mt, raw, err := ws.ReadMessage()
-			in <- ComputeReactiveActionMessage{MessageType: mt, Raw: raw, Error: err}
+
+func ComputeReactiveActionReactiveHandler(factory func(
+	session ComputeReactiveActionSession,
+) (chan []byte, error)) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		read := make(chan ComputeReactiveActionReadChan)
+		done := make(chan bool)
+		c, err := upgraderComputeReactiveAction.Upgrade(ctx.Writer, ctx.Request, nil)
+		if err != nil {
+			c.WriteMessage(websocket.TextMessage, []byte(err.Error()))
+			c.Close()
+			return
 		}
-	}()
-	// Write loop
-	go func() {
-		for msg := range out {
-			if err := ws.WriteMessage(msg.MessageType, msg.Raw); err != nil {
-				// When message is -1, means it's internal error coming out
-				in <- ComputeReactiveActionMessage{MessageType: -1, Error: err}
-				return
+		session := ComputeReactiveActionSession{
+			Ctx:    ctx,
+			Socket: c,
+			Done:   done,
+			Read:   read,
+		}
+		session.QueryParams = ComputeReactiveActionQueryFromGin(ctx)
+		write, err := factory(session)
+		if err != nil {
+			c.WriteMessage(websocket.TextMessage, []byte(err.Error()))
+		}
+		go func() {
+			for {
+				_, data, err := c.ReadMessage()
+				read <- ComputeReactiveActionReadChan{
+					Data:  data,
+					Error: err,
+				}
+				if err != nil {
+					return
+				}
 			}
-		}
-	}()
-	// Run developer code (blocking)
-	handler(session)
-	// Cleanup
-	close(out)
-	ws.Close()
+		}()
+		go func() {
+			for {
+				select {
+				case msg, ok := <-write:
+					if !ok {
+						// Channel closed; shutdown
+						c.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+						done <- true
+						return
+					}
+					msgType := websocket.TextMessage
+					if !utf8.Valid(msg) {
+						msgType = websocket.BinaryMessage
+					}
+					err := c.WriteMessage(msgType, msg)
+					if err != nil {
+						// Optionally log the error or send to a logger
+						done <- true
+						return
+					}
+				case <-done:
+					c.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+					return
+				}
+			}
+		}()
+	}
 }

--- a/examples/fullstack/sdk/ComputeReactiveNoPathAction.go
+++ b/examples/fullstack/sdk/ComputeReactiveNoPathAction.go
@@ -7,24 +7,31 @@ import (
 	"github.com/torabian/emi/examples/fullstack/emigo"
 	"net/http"
 	"net/url"
+	"unicode/utf8"
 )
 
 /**
 * Action to communicate with the action ComputeReactiveNoPathAction
  */
 func ComputeReactiveNoPathActionMeta() struct {
-	Name   string
-	URL    string
-	Method string
+	Name        string
+	URL         string
+	Method      string
+	CliName     string
+	Description string
 } {
 	return struct {
-		Name   string
-		URL    string
-		Method string
+		Name        string
+		URL         string
+		Method      string
+		CliName     string
+		Description string
 	}{
-		Name:   "ComputeReactiveNoPathAction",
-		URL:    "/compute/reactive",
-		Method: "REACTIVE",
+		Name:        "ComputeReactiveNoPathAction",
+		URL:         "/compute/reactive",
+		Method:      "REACTIVE",
+		CliName:     "",
+		Description: "Reactive compute elsasements.",
 	}
 }
 
@@ -88,7 +95,6 @@ type ComputeReactiveNoPathActionMessage struct {
 	Conn        *websocket.Conn
 	MessageType int
 	Error       error
-	QueryParams ComputeReactiveNoPathActionQuery
 }
 
 // Developer handler type
@@ -112,7 +118,6 @@ func ComputeReactiveNoPathAction(r *gin.Engine, handler ComputeReactiveNoPathAct
 				Error:       err,
 				MessageType: mt,
 			}
-			msg.QueryParams = ComputeReactiveNoPathActionQueryFromGin(c)
 			// Provide raw message to developer handler
 			if err := handler(msg); err != nil {
 				errMsg := fmt.Sprintf("handler error: %v", err)
@@ -125,99 +130,78 @@ func ComputeReactiveNoPathAction(r *gin.Engine, handler ComputeReactiveNoPathAct
 }
 
 type ComputeReactiveNoPathActionSession struct {
-	In          <-chan ComputeReactiveNoPathActionMessage
-	Out         chan<- ComputeReactiveNoPathActionMessage
-	Done        <-chan struct{}
-	Close       func(err error)
+	Ctx         *gin.Context
+	Socket      *websocket.Conn
+	Done        chan bool
+	Read        chan ComputeReactiveNoPathActionReadChan
 	QueryParams ComputeReactiveNoPathActionQuery
 }
 type ComputeReactiveNoPathActionHandlerDuplex func(*ComputeReactiveNoPathActionSession)
-
-// ComputeReactiveNoPathActionDuplex upgrades the HTTP connection to a WebSocket and
-// exposes it as a full-duplex, blocking session.
-//
-// The provided handler owns the lifetime of the connection.
-// The WebSocket remains open as long as the handler is running.
-// Returning from the handler will close the connection.
-//
-// Session channels:
-//   - ctx.In   : incoming messages from the client (closed on disconnect)
-//   - ctx.Out  : outgoing messages to the client (blocking send)
-//   - ctx.Done : closed when the server terminates the session
-//
-// Usage pattern:
-//
-//	external.ComputeReactiveNoPathActionDuplex(r, func(ctx *external.ComputeReactiveNoPathActionSession) {
-//		for {
-//			select {
-//			case msg, ok := <-ctx.In:
-//				if !ok {
-//					return // client disconnected
-//				}
-//				ctx.Out <- external.ComputeReactiveNoPathActionMessage{
-//					MessageType: websocket.TextMessage,
-//					Raw:         msg.Raw,
-//				}
-//
-//			case <-ctx.Done:
-//				return // server-side close
-//			}
-//		}
-//	})
-//
-// Important:
-//   - Always read the generated code, don't use blindly.
-//   - If there is an error on write, you'll get a message back, with message type -1 (instead of default websocket message type int.)
-//   - The handler MUST block (typically via a loop).
-//   - Returning from the handler closes the WebSocket.
-//   - Do not treat this as a per-message callback.
-func ComputeReactiveNoPathActionDuplex(r *gin.Engine, handler ComputeReactiveNoPathActionHandlerDuplex) {
-	meta := ComputeReactiveNoPathActionMeta()
-	// The actual callback is extracted, in case you need to handle multiple handlers or customize, use it directly.
-	r.GET(meta.URL, func(ctx *gin.Context) {
-		ComputeReactiveNoPathActionDuplexGinHandler(ctx, handler)
-	})
+type ComputeReactiveNoPathActionReadChan struct {
+	Data  []byte
+	Error error
 }
-func ComputeReactiveNoPathActionDuplexGinHandler(c *gin.Context, handler ComputeReactiveNoPathActionHandlerDuplex) {
-	ws, err := upgraderComputeReactiveNoPathAction.Upgrade(c.Writer, c.Request, nil)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "cannot upgrade websocket"})
-		return
-	}
-	in := make(chan ComputeReactiveNoPathActionMessage)
-	out := make(chan ComputeReactiveNoPathActionMessage)
-	done := make(chan struct{})
-	session := &ComputeReactiveNoPathActionSession{
-		In:   in,
-		Out:  out,
-		Done: done,
-		Close: func(err error) {
-			close(done)
-			ws.Close()
-		},
-	}
-	session.QueryParams = ComputeReactiveNoPathActionQueryFromGin(c)
-	// Read loop
-	go func() {
-		defer close(in)
-		for {
-			mt, raw, err := ws.ReadMessage()
-			in <- ComputeReactiveNoPathActionMessage{MessageType: mt, Raw: raw, Error: err}
+
+func ComputeReactiveNoPathActionReactiveHandler(factory func(
+	session ComputeReactiveNoPathActionSession,
+) (chan []byte, error)) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		read := make(chan ComputeReactiveNoPathActionReadChan)
+		done := make(chan bool)
+		c, err := upgraderComputeReactiveNoPathAction.Upgrade(ctx.Writer, ctx.Request, nil)
+		if err != nil {
+			c.WriteMessage(websocket.TextMessage, []byte(err.Error()))
+			c.Close()
+			return
 		}
-	}()
-	// Write loop
-	go func() {
-		for msg := range out {
-			if err := ws.WriteMessage(msg.MessageType, msg.Raw); err != nil {
-				// When message is -1, means it's internal error coming out
-				in <- ComputeReactiveNoPathActionMessage{MessageType: -1, Error: err}
-				return
+		session := ComputeReactiveNoPathActionSession{
+			Ctx:    ctx,
+			Socket: c,
+			Done:   done,
+			Read:   read,
+		}
+		session.QueryParams = ComputeReactiveNoPathActionQueryFromGin(ctx)
+		write, err := factory(session)
+		if err != nil {
+			c.WriteMessage(websocket.TextMessage, []byte(err.Error()))
+		}
+		go func() {
+			for {
+				_, data, err := c.ReadMessage()
+				read <- ComputeReactiveNoPathActionReadChan{
+					Data:  data,
+					Error: err,
+				}
+				if err != nil {
+					return
+				}
 			}
-		}
-	}()
-	// Run developer code (blocking)
-	handler(session)
-	// Cleanup
-	close(out)
-	ws.Close()
+		}()
+		go func() {
+			for {
+				select {
+				case msg, ok := <-write:
+					if !ok {
+						// Channel closed; shutdown
+						c.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+						done <- true
+						return
+					}
+					msgType := websocket.TextMessage
+					if !utf8.Valid(msg) {
+						msgType = websocket.BinaryMessage
+					}
+					err := c.WriteMessage(msgType, msg)
+					if err != nil {
+						// Optionally log the error or send to a logger
+						done <- true
+						return
+					}
+				case <-done:
+					c.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+					return
+				}
+			}
+		}()
+	}
 }

--- a/lib/golang/go-action-reactive-render.go
+++ b/lib/golang/go-action-reactive-render.go
@@ -162,7 +162,7 @@ func {{ .realms.ActionName }}ReactiveHandler(factory func(
 		read := make(chan {{ .realms.ActionName }}ReadChan)
 		done := make(chan bool)
 
-		c, err := Upgrader.Upgrade(ctx.Writer, ctx.Request, nil)
+		c, err := upgrader{{ .realms.ActionName }}.Upgrade(ctx.Writer, ctx.Request, nil)
 		if err != nil {
 			c.WriteMessage(websocket.TextMessage, []byte(err.Error()))
 

--- a/lib/golang/go-action-realms.go
+++ b/lib/golang/go-action-realms.go
@@ -53,7 +53,7 @@ func GoActionRealms(
 		{
 			Location: "net/http",
 		},
-
+		core.CodeChunkDependency{Location: "io"},
 		{
 			Location: "github.com/gin-gonic/gin",
 		},

--- a/lib/golang/go-struct-generator.go
+++ b/lib/golang/go-struct-generator.go
@@ -433,14 +433,22 @@ func goListAndObjectTypes(field fieldLike, parentChain string) string {
 		}
 		return "[]" + target
 	case core.FieldTypeSlice:
-		return "[]" + goPrimitiveDetect(field.GetPrimitive())
+		return "[]" + DefaultIfEmpty(goPrimitiveDetect(field.GetPrimitive()), "interface{}")
 	case core.FieldTypeSliceNullable:
-		return "[]" + goPrimitiveDetect(field.GetPrimitive())
+		return "[]" + DefaultIfEmpty(goPrimitiveDetect(field.GetPrimitive()), "interface{}")
 	case core.FieldTypeObject:
 		return field.PublicName()
 	default:
 		return "interface{}"
 	}
+}
+
+func DefaultIfEmpty(value string, defaultV string) string {
+	if value == "" {
+		return defaultV
+	}
+
+	return value
 }
 
 func goComputedField(field fieldLike, parentChain string) string {


### PR DESCRIPTION
In case a primitive is unknown, in slice fields we rather have interface{} than broken code.