### PR TITLE
Add manifest generation

### DIFF
--- a/.vscode/emi-module-spec.json
+++ b/.vscode/emi-module-spec.json
@@ -62,6 +62,13 @@
           },
           "type": "array",
           "description": "Server side configuration manager"
+        },
+        "manifests": {
+          "items": {
+            "$ref": "#/definitions/EmiManifest"
+          },
+          "type": "array",
+          "description": "Manifests are a way to create actions bundle"
         }
       },
       "additionalProperties": false,
@@ -466,6 +473,64 @@
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "EmiManifest": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Unique name of the manifest"
+        },
+        "package": {
+          "type": "string",
+          "title": "Name",
+          "description": "Package name used in some programming languages with package"
+        },
+        "mod": {
+          "type": "string",
+          "title": "Name",
+          "description": "Mod package name such as github.com/org/package"
+        },
+        "types": {
+          "items": {
+            "type": "string",
+            "enum": [
+              "go-gin",
+              "go-wasm"
+            ]
+          },
+          "type": "array",
+          "uniqueItems": true,
+          "title": "Types",
+          "description": "List of supported types"
+        },
+        "includes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Includes",
+          "description": "Included actions or patterns (supports wildcards)"
+        },
+        "dist": {
+          "type": "string",
+          "title": "Dist",
+          "description": "The location that manifest will be written"
+        },
+        "excludes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Excludes",
+          "description": "Excluded conditions or patterns"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ]
     },
     "EmiQueryField": {
       "properties": {

--- a/emi-web/docs/emi-module-spec.mdx
+++ b/emi-web/docs/emi-module-spec.mdx
@@ -47,3 +47,4 @@ On the yaml root, you can set different features of a the module, such as entiti
 | `actions` | `array` | Actions are similar to controllers in other frameworks. They are custom functionality available via CLI or Http requests and developer need to implement their logic |
 | `remotes` | `array` | Remotes are definition of external services which could be contacted via http and Emi developer can make them typesafe by defining them here. |
 | `config` | `array` | Server side configuration manager |
+| `manifests` | `array` | Manifests are a way to create actions bundle |

--- a/lib/core/Emi.go
+++ b/lib/core/Emi.go
@@ -33,6 +33,9 @@ type Emi struct {
 
 	// Server side configuration manager, with limited data types, good option for casting .env files.
 	Config []EmiConfig `yaml:"config,omitempty" json:"config,omitempty" jsonschema:"description=Server side configuration manager, with limited data types, good option for casting .env files."`
+
+	// Manifests are a way to create actions bundle, to implement them easier, or wrap them into a single module.
+	Manifests []EmiManifest `yaml:"manifests,omitempty" json:"manifests,omitempty" jsonschema:"description=Manifests are a way to create actions bundle, to implement them easier, or wrap them into a single module."`
 }
 
 func (x *Emi) ActionsAsList() []string {

--- a/lib/core/EmiManifest.go
+++ b/lib/core/EmiManifest.go
@@ -1,0 +1,30 @@
+package core
+
+// EmiManifest defines a manifest configuration used to describe
+// included types and actions along with exclusion rules.
+type EmiManifest struct {
+
+	// Name is the unique identifier of the manifest.
+	Name string `json:"name,omitempty" yaml:"name,omitempty" jsonschema:"title=Name,description=Unique name of the manifest,required"`
+
+	// Package name used in some programming languages with package
+	Package string `json:"package,omitempty" yaml:"package,omitempty" jsonschema:"title=Name,description=Package name used in some programming languages with package"`
+
+	// Mod package name such as github.com/org/package
+	ModPackageName string `json:"mod,omitempty" yaml:"mod,omitempty" jsonschema:"title=Name,description=Mod package name such as github.com/org/package"`
+
+	// Types represents the list of supported runtime or build targets.
+	// Allowed values: go-client, go-gin, go-cli, go-wasm.
+	Types []string `json:"types,omitempty" yaml:"types,omitempty" jsonschema:"title=Types,description=List of supported types,enum=go-clientenum=go-cli,enum=go-gin,enum=go-wasm,uniqueItems=true"`
+
+	// Includes defines the list of actions or patterns to include.
+	// Supports wildcard matching.
+	Includes []string `json:"includes,omitempty" yaml:"includes,omitempty" jsonschema:"title=Includes,description=Included actions or patterns (supports wildcards)"`
+
+	// The location that manifest will be written
+	Dist string `json:"dist,omitempty" yaml:"dist,omitempty" jsonschema:"title=Dist,description=The location that manifest will be written"`
+
+	// Excludes defines the list of conditions or patterns to exclude,
+	// overriding Includes when matched.
+	Excludes []string `json:"excludes,omitempty" yaml:"excludes,omitempty" jsonschema:"title=Excludes,description=Excluded conditions or patterns"`
+}

--- a/lib/golang/go-manifest.go
+++ b/lib/golang/go-manifest.go
@@ -1,0 +1,287 @@
+package golang
+
+import (
+	"bytes"
+	"fmt"
+	"path"
+	"regexp"
+	"slices"
+	"strings"
+	"text/template"
+
+	"github.com/torabian/emi/lib/core"
+)
+
+type manifestRender struct {
+	ActionName      string
+	HasAlias        bool
+	HasRequestFlags bool
+}
+
+func GoManifest(manifest core.EmiManifest, module *core.Emi, ctx core.MicroGenContext) (*core.CodeChunkCompiled, error) {
+
+	const tmpl = `	
+/**
+* Go manifest
+*/
+
+
+{{ if .actions }}
+import (
+	{{$.f.PackageName}} "{{ .mm }}"
+)
+{{ end }}
+
+{{ if .goGin }}
+func {{ upper .manifest.Name }}GinServerSetup(x *gin.Engine) {
+	{{ range .actions }}
+		 {{$.location}} {{ .ActionName }}Gin(x, {{ .ActionName }})
+	{{ end }}
+}
+{{ end }}
+
+{{ if .goClient }}
+func {{ upper .manifest.Name }}ClientCliBundle(client emigo.APIClient) []*cli.Command {
+	return []*cli.Command{
+		{{ range .actions }}
+		Get{{ .ActionName }}ClientCmd(client),
+		{{ end }}
+	}
+}
+{{ end }}
+
+{{ if .goCli }}
+func {{ upper .manifest.Name }}CliManifest() []*cli.Command {
+
+	return []*cli.Command{
+		{{ range .actions }}
+			Get{{ .ActionName }}Cmd(),
+		{{ end }}
+	}
+}
+{{ end }}
+
+
+{{ if .goCli }}
+	{{ range .actions }}
+
+	func Get{{ .ActionName }}Cmd() *cli.Command {
+		return &cli.Command{
+			Name:    {{$.location}} {{ .ActionName }}Meta().CliName,
+			Usage:   {{$.location}} {{ .ActionName }}Meta().Description,
+
+			{{ if .HasAlias }}
+			Aliases: []string{
+				{{$.location}} {{ .ActionName }}Meta().CliShort,
+			},
+			{{ end }}
+
+			{{ if .HasRequestFlags }}
+			Flags:   emigo.CastEmiFlagToUrfave({{$.location}} Get{{ .ActionName }}ReqCliFlags("")),
+			{{ end }}
+			Action: func(ctx context.Context, c *cli.Command) error {
+				return emigo.HandleActionInCli({{ .ActionName }}(
+					{{$.location}} {{ .ActionName }}Request{
+						CliCtx: c,
+
+						{{ if .HasRequestFlags }}
+						Body:   {{$.location}} Cast{{ .ActionName }}ReqFromCli(c),
+						{{ end }}
+					},
+				))
+			},
+		}
+	}
+
+	{{ end }}
+{{ end }}
+
+{{ if .goClient }}
+	{{ range .actions }}
+	func Get{{ .ActionName }}ClientCmd(client emigo.APIClient) *cli.Command {
+		return &cli.Command{
+			Name:    {{$.location}}{{ .ActionName }}Meta().CliName,
+			Usage:   {{$.location}}{{ .ActionName }}Meta().Description,
+
+			{{ if .HasAlias }}
+			Aliases: []string{
+				{{$.location}}{{ .ActionName }}Meta().CliShort,
+			},
+			{{ end }}
+
+			{{ if .HasRequestFlags }}
+			Flags:   emigo.CastEmiFlagToUrfave({{$.location}}Get{{ .ActionName }}ReqCliFlags("")),
+			{{ end }}
+			Action: func(ctx context.Context, c *cli.Command) error {
+				return emigo.HandleActionInCli({{$.location}}{{ .ActionName }}Call(
+					{{$.location}}{{ .ActionName }}Request{
+						CliCtx: c,
+
+						{{ if .HasRequestFlags }}
+						Body:   {{$.location}}Cast{{ .ActionName }}ReqFromCli(c),
+						{{ end }}
+					},
+					&client,
+				))
+			},
+		}
+	}
+	{{ end }}
+{{ end }}
+
+`
+
+	type Flags struct {
+		Emigo       string `json:"emigo,omitempty"`
+		PackageName string `json:"pkg,omitempty"`
+	}
+	var f Flags = Flags{
+		Emigo:       "github.com/torabian/emi/emigo",
+		PackageName: DEFAULT_GO_PACKAGE,
+	}
+
+	if val, ok := ctx.Flags["emigo"]; ok && val != "" {
+		f.Emigo = val
+	}
+
+	if val, ok := ctx.Flags["pkg"]; ok && val != "" {
+		f.PackageName = val
+	}
+
+	rendered := []manifestRender{}
+
+	for _, action := range module.Actions {
+
+		act, _ := GoActionRender(action, ctx, []RecognizedComplex{})
+
+		actionName := core.FindTokenByName(
+			act.Tokens,
+			core.TOKEN_ORIGINAL_NAME,
+		).Value
+
+		if !shouldRenderAction(
+			action.Name,
+			manifest.Includes,
+			manifest.Excludes,
+		) {
+			continue
+		}
+
+		rendered = append(rendered, manifestRender{
+			ActionName:      actionName,
+			HasAlias:        action.GetCliShort() != "",
+			HasRequestFlags: action.HasRequestFields(),
+		})
+	}
+
+	t := template.Must(template.New("go_manifest").Funcs(core.CommonMap).Parse(tmpl))
+	res := &core.CodeChunkCompiled{
+		Tokens: []core.GeneratedScriptToken{
+			{
+				Name:  "PACKAGE_NAME",
+				Value: manifest.Package,
+			},
+		},
+		CodeChunkDependensies: []core.CodeChunkDependency{},
+	}
+
+	mm := path.Join(manifest.ModPackageName, ctx.Output)
+
+	goClient := slices.Contains(manifest.Types, "go-client")
+	goCli := slices.Contains(manifest.Types, "go-cli")
+	goGin := slices.Contains(manifest.Types, "go-gin")
+
+	if goClient || goCli {
+		res.CodeChunkDependensies = append(
+			res.CodeChunkDependensies,
+			core.CodeChunkDependency{
+				Location: "github.com/urfave/cli/v3",
+			},
+		)
+
+		if len(rendered) > 0 {
+			res.CodeChunkDependensies = append(
+				res.CodeChunkDependensies,
+				core.CodeChunkDependency{
+					Location: "context",
+				},
+				core.CodeChunkDependency{
+					Location: f.Emigo,
+				},
+			)
+		}
+	}
+
+	if goGin {
+		res.CodeChunkDependensies = append(
+			res.CodeChunkDependensies,
+			core.CodeChunkDependency{
+				Location: "github.com/gin-gonic/gin",
+			},
+		)
+	}
+
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, core.H{
+		"actions":  rendered,
+		"location": fmt.Sprintf("%v.", f.PackageName),
+		"manifest": manifest,
+		"goClient": goClient,
+		"goCli":    goCli,
+		"goGin":    goGin,
+		"mm":       mm,
+		"f":        f,
+		"ctx":      ctx,
+	}); err != nil {
+		return nil, err
+	}
+
+	res.ActualScript = buf.Bytes()
+	res.SuggestedExtension = ".go"
+	res.SuggestedFileName = path.Join(
+		manifest.Dist,
+		fmt.Sprintf("%vManifest", core.ToUpper(manifest.Name)),
+	)
+
+	return res, nil
+}
+
+func matchAction(name string, patterns []string) bool {
+	for _, p := range patterns {
+
+		// convenience wildcard
+		if p == "*" {
+			return true
+		}
+
+		if name == p {
+			return true
+		}
+
+		// convert shell-like wildcard
+		// User* -> User.*
+		p = strings.ReplaceAll(p, "*", ".*")
+
+		ok, err := regexp.MatchString("^"+p+"$", name)
+		if err == nil && ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+func shouldRenderAction(name string, includes, excludes []string) bool {
+
+	// include mode
+	if len(includes) > 0 && !matchAction(name, includes) {
+		return false
+	}
+
+	// exclude mode
+	if matchAction(name, excludes) {
+		return false
+	}
+
+	return true
+}

--- a/lib/golang/go-public-api.go
+++ b/lib/golang/go-public-api.go
@@ -150,7 +150,6 @@ func GoModuleFull(module *core.Emi, ctx core.MicroGenContext) ([]core.VirtualFil
 	}
 
 	if val, ok := ctx.Flags["pkg"]; ok && val != "" {
-		fmt.Println("Setting packagename", val)
 		f.PackageName = val
 	}
 
@@ -185,8 +184,6 @@ func GoModuleFull(module *core.Emi, ctx core.MicroGenContext) ([]core.VirtualFil
 		entitiesAndDtos = append(entitiesAndDtos, actionRendered)
 	}
 
-	// internalUsage := []string{}
-
 	for _, dtoItem := range entitiesAndDtos {
 		for _, loc := range dtoItem.CodeChunkDependensies {
 			// I don't remember this
@@ -204,8 +201,6 @@ func GoModuleFull(module *core.Emi, ctx core.MicroGenContext) ([]core.VirtualFil
 		})
 	}
 
-	// var actionsRendered []*core.CodeChunkCompiled
-
 	for _, action := range module.Actions {
 
 		output, err := GoActionRender(action, ctx, complexes)
@@ -218,6 +213,19 @@ func GoModuleFull(module *core.Emi, ctx core.MicroGenContext) ([]core.VirtualFil
 			Name:         output.SuggestedFileName,
 			Extension:    output.SuggestedExtension,
 			ActualScript: AsFullDocument(output, f.PackageName),
+		})
+	}
+
+	for _, manifest := range module.Manifests {
+		gomanifest, err := GoManifest(manifest, module, ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		files = append(files, core.VirtualFile{
+			Name:         gomanifest.SuggestedFileName,
+			Extension:    gomanifest.SuggestedExtension,
+			ActualScript: AsFullDocument(gomanifest, f.PackageName),
 		})
 	}
 
@@ -249,6 +257,11 @@ func FormatGoCode(code string) string {
 }
 
 func AsFullDocument(x *core.CodeChunkCompiled, packageName string) string {
+
+	if item := core.FindTokenByName(x.Tokens, "PACKAGE_NAME"); item != nil {
+		packageName = item.Value
+	}
+
 	importsList := CombineGoImports(*x)
 	var finalContent string = "package " + packageName + "\r\n" + importsList + "\r\n" + string(x.ActualScript)
 

--- a/playground/public/emi-module-spec.json
+++ b/playground/public/emi-module-spec.json
@@ -62,6 +62,13 @@
           },
           "type": "array",
           "description": "Server side configuration manager"
+        },
+        "manifests": {
+          "items": {
+            "$ref": "#/definitions/EmiManifest"
+          },
+          "type": "array",
+          "description": "Manifests are a way to create actions bundle"
         }
       },
       "additionalProperties": false,
@@ -466,6 +473,64 @@
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "EmiManifest": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Unique name of the manifest"
+        },
+        "package": {
+          "type": "string",
+          "title": "Name",
+          "description": "Package name used in some programming languages with package"
+        },
+        "mod": {
+          "type": "string",
+          "title": "Name",
+          "description": "Mod package name such as github.com/org/package"
+        },
+        "types": {
+          "items": {
+            "type": "string",
+            "enum": [
+              "go-gin",
+              "go-wasm"
+            ]
+          },
+          "type": "array",
+          "uniqueItems": true,
+          "title": "Types",
+          "description": "List of supported types"
+        },
+        "includes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Includes",
+          "description": "Included actions or patterns (supports wildcards)"
+        },
+        "dist": {
+          "type": "string",
+          "title": "Dist",
+          "description": "The location that manifest will be written"
+        },
+        "excludes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Excludes",
+          "description": "Excluded conditions or patterns"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ]
     },
     "EmiQueryField": {
       "properties": {


### PR DESCRIPTION
Adds a manifest generation into the Emi compiler. Now functions are having Gin, Cmd, and Client cmd manifest generation, with option to include or exclude them, for general purposes.