### PR TITLE
Make it work on more stricter typescript scenario

### DIFF
--- a/envelopes/src/google-json-style-guide/generated/ResponseDto.ts
+++ b/envelopes/src/google-json-style-guide/generated/ResponseDto.ts
@@ -190,12 +190,12 @@ export class ResponseDto<T> {
      * Single item returned by the API.
      * @type {any}
      **/
-    #item: T = null;
+    #item: T | null = null;
     /**
      * Single item returned by the API.
      * @returns {T}
      **/
-    get item(): T {
+    get item(): T | null {
       return this.#item;
     }
     /**
@@ -213,22 +213,22 @@ export class ResponseDto<T> {
      * List of items returned by the API.
      * @type {any}
      **/
-    #items: any = null;
+    #items: T[] = [];
     /**
      * List of items returned by the API.
-     * @returns {any}
+     * @returns {T[]}
      **/
-    get items() {
+    get items(): T[] {
       return this.#items;
     }
     /**
      * List of items returned by the API.
-     * @type {any}
+     * @type {T[]}
      **/
-    set items(value: any) {
+    set items(value: T[]) {
       this.#items = value;
     }
-    setItems(value: any) {
+    setItems(value: T[]) {
       this.items = value;
       return this;
     }

--- a/examples/js-test/reactclient/src/generated/sdk/common/fetchx.ts
+++ b/examples/js-test/reactclient/src/generated/sdk/common/fetchx.ts
@@ -148,12 +148,12 @@ export class FetchxContext {
      * Overrides the browser fetch function, for different purposes. It would recieve the same first 2 arguments as fetch,
      * as well as third one of fetchx context. If you pass the fetch itself to override, it should have no effect.
      */
-    public fetchOverrideFn: (
+    public fetchOverrideFn?: (
       input: RequestInfo | URL,
       init?: TypedRequestInit,
-    ) => Promise<Response> = null,
+    ) => Promise<Response>,
   ) {}
-  async apply<T>(
+  async apply(
     url: string,
     init: TypedRequestInit<any, any>,
   ): Promise<[string, TypedRequestInit<any, any>]> {

--- a/examples/js-test/reactclient/src/generated/sdk/envelopes/google-json-style-guide/generated/ResponseDto.ts
+++ b/examples/js-test/reactclient/src/generated/sdk/envelopes/google-json-style-guide/generated/ResponseDto.ts
@@ -190,12 +190,12 @@ export class ResponseDto<T> {
      * Single item returned by the API.
      * @type {any}
      **/
-    #item: T = null;
+    #item: T | null = null;
     /**
      * Single item returned by the API.
      * @returns {T}
      **/
-    get item(): T {
+    get item(): T | null {
       return this.#item;
     }
     /**
@@ -213,22 +213,22 @@ export class ResponseDto<T> {
      * List of items returned by the API.
      * @type {any}
      **/
-    #items: any = null;
+    #items: T[] = [];
     /**
      * List of items returned by the API.
-     * @returns {any}
+     * @returns {T[]}
      **/
-    get items() {
+    get items(): T[] {
       return this.#items;
     }
     /**
      * List of items returned by the API.
-     * @type {any}
+     * @type {T[]}
      **/
-    set items(value: any) {
+    set items(value: T[]) {
       this.#items = value;
     }
-    setItems(value: any) {
+    setItems(value: T[]) {
       this.items = value;
       return this;
     }

--- a/js-sdk-kit/build/common/fetchx.d.ts
+++ b/js-sdk-kit/build/common/fetchx.d.ts
@@ -27,14 +27,14 @@ export declare class FetchxContext {
      * Overrides the browser fetch function, for different purposes. It would recieve the same first 2 arguments as fetch,
      * as well as third one of fetchx context. If you pass the fetch itself to override, it should have no effect.
      */
-    fetchOverrideFn: (input: RequestInfo | URL, init?: TypedRequestInit) => Promise<Response>;
+    fetchOverrideFn?: (input: RequestInfo | URL, init?: TypedRequestInit) => Promise<Response>;
     constructor(baseUrl?: string, defaultHeaders?: Record<string, string>, requestInterceptor?: (url: string, init: TypedRequestInit<any, any>) => Promise<[string, TypedRequestInit<any, any>]> | [string, TypedRequestInit<any, any>], responseInterceptor?: <T>(res: TypedResponse<T>) => Promise<TypedResponse<T>>, 
     /**
      * Overrides the browser fetch function, for different purposes. It would recieve the same first 2 arguments as fetch,
      * as well as third one of fetchx context. If you pass the fetch itself to override, it should have no effect.
      */
     fetchOverrideFn?: (input: RequestInfo | URL, init?: TypedRequestInit) => Promise<Response>);
-    apply<T>(url: string, init: TypedRequestInit<any, any>): Promise<[string, TypedRequestInit<any, any>]>;
+    apply(url: string, init: TypedRequestInit<any, any>): Promise<[string, TypedRequestInit<any, any>]>;
     handle<T>(res: TypedResponse<T>): Promise<TypedResponse<T>>;
     clone(overrides?: Partial<FetchxContext>): FetchxContext;
 }

--- a/js-sdk-kit/build/common/fetchx.js
+++ b/js-sdk-kit/build/common/fetchx.js
@@ -106,7 +106,7 @@ export class FetchxContext {
      * Overrides the browser fetch function, for different purposes. It would recieve the same first 2 arguments as fetch,
      * as well as third one of fetchx context. If you pass the fetch itself to override, it should have no effect.
      */
-    fetchOverrideFn = null) {
+    fetchOverrideFn) {
         this.baseUrl = baseUrl;
         this.defaultHeaders = defaultHeaders;
         this.requestInterceptor = requestInterceptor;

--- a/js-sdk-kit/src/common/fetchx.ts
+++ b/js-sdk-kit/src/common/fetchx.ts
@@ -148,12 +148,12 @@ export class FetchxContext {
      * Overrides the browser fetch function, for different purposes. It would recieve the same first 2 arguments as fetch,
      * as well as third one of fetchx context. If you pass the fetch itself to override, it should have no effect.
      */
-    public fetchOverrideFn: (
+    public fetchOverrideFn?: (
       input: RequestInfo | URL,
       init?: TypedRequestInit,
-    ) => Promise<Response> = null,
+    ) => Promise<Response>,
   ) {}
-  async apply<T>(
+  async apply(
     url: string,
     init: TypedRequestInit<any, any>,
   ): Promise<[string, TypedRequestInit<any, any>]> {

--- a/lib/js/ts-envelopes/google-json-style-guide/generated/ResponseDto.ts
+++ b/lib/js/ts-envelopes/google-json-style-guide/generated/ResponseDto.ts
@@ -190,12 +190,12 @@ export class ResponseDto<T> {
      * Single item returned by the API.
      * @type {any}
      **/
-    #item: T = null;
+    #item: T | null = null;
     /**
      * Single item returned by the API.
      * @returns {T}
      **/
-    get item(): T {
+    get item(): T | null {
       return this.#item;
     }
     /**
@@ -213,22 +213,22 @@ export class ResponseDto<T> {
      * List of items returned by the API.
      * @type {any}
      **/
-    #items: any = null;
+    #items: T[] = [];
     /**
      * List of items returned by the API.
-     * @returns {any}
+     * @returns {T[]}
      **/
-    get items() {
+    get items(): T[] {
       return this.#items;
     }
     /**
      * List of items returned by the API.
-     * @type {any}
+     * @type {T[]}
      **/
-    set items(value: any) {
+    set items(value: T[]) {
       this.#items = value;
     }
-    setItems(value: any) {
+    setItems(value: T[]) {
       this.items = value;
       return this;
     }

--- a/lib/js/ts-sdk/common/fetchx.ts
+++ b/lib/js/ts-sdk/common/fetchx.ts
@@ -148,12 +148,12 @@ export class FetchxContext {
      * Overrides the browser fetch function, for different purposes. It would recieve the same first 2 arguments as fetch,
      * as well as third one of fetchx context. If you pass the fetch itself to override, it should have no effect.
      */
-    public fetchOverrideFn: (
+    public fetchOverrideFn?: (
       input: RequestInfo | URL,
       init?: TypedRequestInit,
-    ) => Promise<Response> = null,
+    ) => Promise<Response>,
   ) {}
-  async apply<T>(
+  async apply(
     url: string,
     init: TypedRequestInit<any, any>,
   ): Promise<[string, TypedRequestInit<any, any>]> {

--- a/tests/js/test-artifacts/http-action-test-output/sdk/common/fetchx.ts
+++ b/tests/js/test-artifacts/http-action-test-output/sdk/common/fetchx.ts
@@ -148,12 +148,12 @@ export class FetchxContext {
      * Overrides the browser fetch function, for different purposes. It would recieve the same first 2 arguments as fetch,
      * as well as third one of fetchx context. If you pass the fetch itself to override, it should have no effect.
      */
-    public fetchOverrideFn: (
+    public fetchOverrideFn?: (
       input: RequestInfo | URL,
       init?: TypedRequestInit,
-    ) => Promise<Response> = null,
+    ) => Promise<Response>,
   ) {}
-  async apply<T>(
+  async apply(
     url: string,
     init: TypedRequestInit<any, any>,
   ): Promise<[string, TypedRequestInit<any, any>]> {

--- a/tests/js/test-artifacts/http-action-test-output/sdk/envelopes/google-json-style-guide/generated/ResponseDto.ts
+++ b/tests/js/test-artifacts/http-action-test-output/sdk/envelopes/google-json-style-guide/generated/ResponseDto.ts
@@ -190,12 +190,12 @@ export class ResponseDto<T> {
      * Single item returned by the API.
      * @type {any}
      **/
-    #item: T = null;
+    #item: T | null = null;
     /**
      * Single item returned by the API.
      * @returns {T}
      **/
-    get item(): T {
+    get item(): T | null {
       return this.#item;
     }
     /**
@@ -213,22 +213,22 @@ export class ResponseDto<T> {
      * List of items returned by the API.
      * @type {any}
      **/
-    #items: any = null;
+    #items: T[] = [];
     /**
      * List of items returned by the API.
-     * @returns {any}
+     * @returns {T[]}
      **/
-    get items() {
+    get items(): T[] {
       return this.#items;
     }
     /**
      * List of items returned by the API.
-     * @type {any}
+     * @type {T[]}
      **/
-    set items(value: any) {
+    set items(value: T[]) {
       this.#items = value;
     }
-    setItems(value: any) {
+    setItems(value: T[]) {
       this.items = value;
       return this;
     }

--- a/tests/js/test-artifacts/http-emi-react-output/sdk/common/fetchx.ts
+++ b/tests/js/test-artifacts/http-emi-react-output/sdk/common/fetchx.ts
@@ -148,12 +148,12 @@ export class FetchxContext {
      * Overrides the browser fetch function, for different purposes. It would recieve the same first 2 arguments as fetch,
      * as well as third one of fetchx context. If you pass the fetch itself to override, it should have no effect.
      */
-    public fetchOverrideFn: (
+    public fetchOverrideFn?: (
       input: RequestInfo | URL,
       init?: TypedRequestInit,
-    ) => Promise<Response> = null,
+    ) => Promise<Response>,
   ) {}
-  async apply<T>(
+  async apply(
     url: string,
     init: TypedRequestInit<any, any>,
   ): Promise<[string, TypedRequestInit<any, any>]> {

--- a/tests/js/test-artifacts/http-emi-react-output/sdk/envelopes/google-json-style-guide/generated/ResponseDto.ts
+++ b/tests/js/test-artifacts/http-emi-react-output/sdk/envelopes/google-json-style-guide/generated/ResponseDto.ts
@@ -190,12 +190,12 @@ export class ResponseDto<T> {
      * Single item returned by the API.
      * @type {any}
      **/
-    #item: T = null;
+    #item: T | null = null;
     /**
      * Single item returned by the API.
      * @returns {T}
      **/
-    get item(): T {
+    get item(): T | null {
       return this.#item;
     }
     /**
@@ -213,22 +213,22 @@ export class ResponseDto<T> {
      * List of items returned by the API.
      * @type {any}
      **/
-    #items: any = null;
+    #items: T[] = [];
     /**
      * List of items returned by the API.
-     * @returns {any}
+     * @returns {T[]}
      **/
-    get items() {
+    get items(): T[] {
       return this.#items;
     }
     /**
      * List of items returned by the API.
-     * @type {any}
+     * @type {T[]}
      **/
-    set items(value: any) {
+    set items(value: T[]) {
       this.#items = value;
     }
-    setItems(value: any) {
+    setItems(value: T[]) {
       this.items = value;
       return this;
     }

--- a/tests/js/test-artifacts/http-envelop-test-output/sdk/common/fetchx.ts
+++ b/tests/js/test-artifacts/http-envelop-test-output/sdk/common/fetchx.ts
@@ -148,12 +148,12 @@ export class FetchxContext {
      * Overrides the browser fetch function, for different purposes. It would recieve the same first 2 arguments as fetch,
      * as well as third one of fetchx context. If you pass the fetch itself to override, it should have no effect.
      */
-    public fetchOverrideFn: (
+    public fetchOverrideFn?: (
       input: RequestInfo | URL,
       init?: TypedRequestInit,
-    ) => Promise<Response> = null,
+    ) => Promise<Response>,
   ) {}
-  async apply<T>(
+  async apply(
     url: string,
     init: TypedRequestInit<any, any>,
   ): Promise<[string, TypedRequestInit<any, any>]> {

--- a/tests/js/test-artifacts/http-envelop-test-output/sdk/envelopes/google-json-style-guide/generated/ResponseDto.ts
+++ b/tests/js/test-artifacts/http-envelop-test-output/sdk/envelopes/google-json-style-guide/generated/ResponseDto.ts
@@ -190,12 +190,12 @@ export class ResponseDto<T> {
      * Single item returned by the API.
      * @type {any}
      **/
-    #item: T = null;
+    #item: T | null = null;
     /**
      * Single item returned by the API.
      * @returns {T}
      **/
-    get item(): T {
+    get item(): T | null {
       return this.#item;
     }
     /**
@@ -213,22 +213,22 @@ export class ResponseDto<T> {
      * List of items returned by the API.
      * @type {any}
      **/
-    #items: any = null;
+    #items: T[] = [];
     /**
      * List of items returned by the API.
-     * @returns {any}
+     * @returns {T[]}
      **/
-    get items() {
+    get items(): T[] {
       return this.#items;
     }
     /**
      * List of items returned by the API.
-     * @type {any}
+     * @type {T[]}
      **/
-    set items(value: any) {
+    set items(value: T[]) {
       this.#items = value;
     }
-    setItems(value: any) {
+    setItems(value: T[]) {
       this.items = value;
       return this;
     }

--- a/tests/js/test-artifacts/web-socket-test-output/sdk/common/fetchx.ts
+++ b/tests/js/test-artifacts/web-socket-test-output/sdk/common/fetchx.ts
@@ -148,12 +148,12 @@ export class FetchxContext {
      * Overrides the browser fetch function, for different purposes. It would recieve the same first 2 arguments as fetch,
      * as well as third one of fetchx context. If you pass the fetch itself to override, it should have no effect.
      */
-    public fetchOverrideFn: (
+    public fetchOverrideFn?: (
       input: RequestInfo | URL,
       init?: TypedRequestInit,
-    ) => Promise<Response> = null,
+    ) => Promise<Response>,
   ) {}
-  async apply<T>(
+  async apply(
     url: string,
     init: TypedRequestInit<any, any>,
   ): Promise<[string, TypedRequestInit<any, any>]> {

--- a/tests/js/test-artifacts/web-socket-test-output/sdk/envelopes/google-json-style-guide/generated/ResponseDto.ts
+++ b/tests/js/test-artifacts/web-socket-test-output/sdk/envelopes/google-json-style-guide/generated/ResponseDto.ts
@@ -190,12 +190,12 @@ export class ResponseDto<T> {
      * Single item returned by the API.
      * @type {any}
      **/
-    #item: T = null;
+    #item: T | null = null;
     /**
      * Single item returned by the API.
      * @returns {T}
      **/
-    get item(): T {
+    get item(): T | null {
       return this.#item;
     }
     /**
@@ -213,22 +213,22 @@ export class ResponseDto<T> {
      * List of items returned by the API.
      * @type {any}
      **/
-    #items: any = null;
+    #items: T[] = [];
     /**
      * List of items returned by the API.
-     * @returns {any}
+     * @returns {T[]}
      **/
-    get items() {
+    get items(): T[] {
       return this.#items;
     }
     /**
      * List of items returned by the API.
-     * @type {any}
+     * @type {T[]}
      **/
-    set items(value: any) {
+    set items(value: T[]) {
       this.#items = value;
     }
-    setItems(value: any) {
+    setItems(value: T[]) {
       this.items = value;
       return this;
     }


### PR DESCRIPTION
Minor change to sdk generated code, which can compile without ts-ignore on more strict configuration.