### PR TITLE
Initial support for permissions in Kotlin, Swift, Javascript, and Golang

### DIFF
--- a/.vscode/emi-module-spec.json
+++ b/.vscode/emi-module-spec.json
@@ -94,6 +94,13 @@
         "templates": {
           "$ref": "#/definitions/EmiTemplate",
           "description": "Reusable shape definitions (dtos"
+        },
+        "permissions": {
+          "items": {
+            "$ref": "#/definitions/EmiPermission"
+          },
+          "type": "array",
+          "description": "Tree of access control permissions this module contributes. Compiled into a usable Permissions constant/tree per target language."
         }
       },
       "additionalProperties": false,
@@ -637,6 +644,45 @@
       "required": [
         "name"
       ]
+    },
+    "EmiPermission": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Programmatic identifier of this permission used to name the generated constant/variable (e.g. Name: 'name' generates NamePermission)."
+        },
+        "title": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Human readable label of the permission"
+        },
+        "description": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Explains what granting this permission allows"
+        },
+        "key": {
+          "type": "string",
+          "description": "Short identifier of this permission"
+        },
+        "fullKey": {
+          "type": "string",
+          "description": "Fully qualified dot separated identifier. If left empty it is computed as the parent FullKey plus this Key while the module is preprocessed."
+        },
+        "children": {
+          "items": {
+            "$ref": "#/definitions/EmiPermission"
+          },
+          "type": "array",
+          "description": "Permissions nested under this one"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     },
     "EmiQueryField": {
       "properties": {

--- a/emigo/Permission.go
+++ b/emigo/Permission.go
@@ -1,0 +1,42 @@
+package emigo
+
+// Permission is a single node of a module's permission tree, as declared via the
+// module's `permissions:` yaml block and compiled by the emi go compiler (see
+// lib/golang/go-permissions.go). It lives here, in the shared runtime, instead of
+// being redefined at the top of every generated Permissions.go.
+//
+// Key is the fully qualified, dot separated identifier (e.g. "post.create") - not
+// the short per-node slug from yaml. A node that groups children and whose key was
+// left for the compiler to derive gets a trailing "*" (e.g. "post*"), signaling it
+// covers itself and everything below it; a key set explicitly in yaml is used as-is.
+//
+// Children is keyed by each child's Name (falling back to its Key when Name isn't
+// set), so a permission tree can be walked by name - e.g. Permissions["managePosts"]
+// .Children["createPost"] - instead of scanning a slice by position.
+type Permission struct {
+	Key         string
+	Name        string
+	Title       map[string]string
+	Description map[string]string
+	Children    map[string]*Permission
+}
+
+func (x Permission) GetTitle() map[string]string {
+	return x.Title
+}
+
+func (x Permission) GetDescription() map[string]string {
+	return x.Description
+}
+
+func (x Permission) GetKey() string {
+	return x.Key
+}
+
+func (x Permission) GetName() string {
+	return x.Name
+}
+
+func (x Permission) GetChildren() map[string]*Permission {
+	return x.Children
+}

--- a/examples/emi-web/src/content/docs/emi-module-spec.mdx
+++ b/examples/emi-web/src/content/docs/emi-module-spec.mdx
@@ -136,5 +136,11 @@ On the yaml root, you can set different features of a module, such as entities, 
             <td>Reusable shape definitions (dtos</td>
           </tr>
         
+          <tr>
+            <td><code>permissions</code></td>
+            <td><code>array</code></td>
+            <td>Tree of access control permissions this module contributes. Compiled into a usable Permissions constant/tree per target language.</td>
+          </tr>
+        
         </tbody>
       </table>

--- a/examples/emi-web/src/content/docs/golang/golang-permissions.mdx
+++ b/examples/emi-web/src/content/docs/golang/golang-permissions.mdx
@@ -1,0 +1,132 @@
+---
+title: "Permissions"
+sidebar:
+  order: 20
+---
+
+A module can declare a `permissions:` tree — a nested set of access control
+permissions the module contributes. Each permission has a `key` (its slug in the
+generated identifier) and a `name` (a programmatic identifier the compiler uses to
+name the generated Go var for it, e.g. `name: managePosts` generates `var
+ManagePostsPermission`). The identifier itself is either set explicitly via
+`fullKey:` or computed by the compiler as `{parent.fullKey}.{key}` while the module
+is preprocessed. If `key` is left empty too, it's normalized from `name` (e.g.
+`name: managePosts` with no `key` becomes `key: managePosts`).
+
+```yaml
+name: blog
+permissions:
+  - key: post
+    name: managePosts
+    title:
+      en: Manage posts
+    description:
+      en: Permissions related to blog posts
+    children:
+      - key: create
+        name: createPost
+        title:
+          en: Create post
+      - key: publish
+        name: publishPost
+        title:
+          en: Publish post
+```
+
+`post` gets no explicit `fullKey`, so the compiler derives one: `post`. Its children
+inherit that as their prefix, becoming `post.create` and `post.publish`. Because
+`post` groups children *and* left its key for the compiler to derive, its generated
+key gets a trailing `.*` — `post.*` — signaling it covers itself and everything below
+it. A `fullKey` set explicitly is always used as-is, even on a node with children,
+since the author chose that exact string on purpose.
+
+Compiling this produces `Permissions.go`:
+
+- one exported var **per root permission** — not a single var wrapping the whole
+  forest, and no separate flat constant per node either (unlike the JS/Kotlin/Swift
+  compilers) since one would just be the same string under a second, disconnected
+  name to keep in sync. Each var is a fully typed, nested struct: every node embeds
+  `emigo.Permission` (so its own `Key` is promoted) and has one field per child, so
+  your editor can autocomplete straight down it with no map lookup and no risk of a
+  typo'd key only failing at runtime, e.g. `ManagePostsPermission.CreatePost.Key`. A
+  root with no children collapses to a plain `emigo.Permission` value. A root var's
+  own name is always PascalCase with a trailing `Permission` (e.g. `managePosts` →
+  `ManagePostsPermission`) — never the bare name a nested child field gets — so a
+  root reads unambiguously as a permission at a glance and two unrelated
+  single-letter roots can't collide.
+- alongside each root var, a `<Name>PermissionList` var: that root permission and
+  every one of its descendants, flattened into its own `[]emigo.Permission` (e.g.
+  `ManagePostsPermissionList` next to `ManagePostsPermission`), built by referencing
+  the root var's own fields (e.g. `ManagePostsPermission.CreatePost`) rather than
+  re-declaring separate literals, so it can never drift out of sync with it. One
+  list per root, not a single list combining every root — a module with several
+  unrelated permission groups shouldn't force every caller to filter one combined
+  list back down to the group it actually cares about.
+
+The `Permission` type itself is `emigo.Permission` — it lives once in the shared
+`emigo` runtime instead of being redefined at the top of every generated
+`Permissions.go`.
+
+Each node's own `emigo.Permission{...}` value is rendered with `Key`/`Name`/`Title`/
+`Description` each on their own line rather than one long comma-separated line: with
+`Title`/`Description` often multi-entry maps, one line per node would get
+unreadably long fast, and gofmt only aligns a composite literal's fields onto
+separate lines when the source already breaks it that way — it won't reflow a
+long single-line literal into one for you.
+
+```go
+package blog
+
+import "github.com/torabian/emi/emigo"
+
+/**
+* Permission keys generated from the module's permissions tree.
+ */
+// ManagePostsPermission mirrors the "managePosts" permission node (and everything nested under it),
+// so it can be navigated directly, e.g. ManagePostsPermission.Key.
+var ManagePostsPermission = struct {
+	emigo.Permission
+	CreatePost  emigo.Permission
+	PublishPost emigo.Permission
+}{
+	Permission: emigo.Permission{
+		Key:         "post.*",
+		Name:        "managePosts",
+		Title:       map[string]string{"en": "Manage posts"},
+		Description: map[string]string{"en": "Permissions related to blog posts"},
+	},
+	CreatePost: emigo.Permission{
+		Key:         "post.create",
+		Name:        "createPost",
+		Title:       map[string]string{"en": "Create post"},
+		Description: nil,
+	},
+	PublishPost: emigo.Permission{
+		Key:         "post.publish",
+		Name:        "publishPost",
+		Title:       map[string]string{"en": "Publish post"},
+		Description: nil,
+	},
+}
+
+// ManagePostsPermissionList flattens ManagePostsPermission (and everything nested under it) into a single slice,
+// for anything that wants to walk them all at once (seeding an ACL table,
+// rendering a permissions picker, ...).
+var ManagePostsPermissionList = []emigo.Permission{
+	ManagePostsPermission.Permission,
+	ManagePostsPermission.CreatePost,
+	ManagePostsPermission.PublishPost,
+}
+```
+
+A module with a second, unrelated root permission (e.g. `viewReports`, with no
+children) gets its own separate `ViewReportsPermission` var and its own separate
+`ViewReportsPermissionList` right alongside it — not folded into
+`ManagePostsPermissionList`.
+
+If a child's own field name happens to collide with the name a branch node's self
+value would otherwise be embedded under (`Permission` — e.g. a child literally
+named `permission`), that branch's self value is instead given the explicit field
+name `Permission_` so nothing gets silently overwritten, and that root's `List`
+references it under that same name (e.g. `WorkspacesPermission.Permission_` inside
+`WorkspacesPermissionList`).

--- a/examples/emi-web/src/content/docs/js/emi-permissions.mdx
+++ b/examples/emi-web/src/content/docs/js/emi-permissions.mdx
@@ -1,0 +1,131 @@
+---
+title: "Permissions"
+sidebar:
+  order: 20
+---
+
+A module can declare a `permissions:` tree — a nested set of access control
+permissions the module contributes. Each permission has a `key` (its slug in the
+generated identifier) and a `name` (a programmatic identifier the compiler uses to
+name the generated const for it, e.g. `name: managePosts` generates
+`ManagePostsPermission`). The identifier itself is either set explicitly via
+`fullKey:` or computed by the compiler as `{parent.fullKey}.{key}` while the module
+is preprocessed. If `key` is left empty too, it's
+normalized from `name` (e.g. `name: managePosts` with no `key` becomes `key:
+managePosts`).
+
+```yaml
+name: blog
+permissions:
+  - key: post
+    name: managePosts
+    title:
+      en: Manage posts
+    description:
+      en: Permissions related to blog posts
+    children:
+      - key: create
+        name: createPost
+        title:
+          en: Create post
+      - key: publish
+        name: publishPost
+        title:
+          en: Publish post
+```
+
+`post` gets no explicit `fullKey`, so the compiler derives one: `post`. Its children
+inherit that as their prefix, becoming `post.create` and `post.publish`. Because
+`post` groups children *and* left its key for the compiler to derive, its generated
+key gets a trailing `.*` — `post.*` — signaling it covers itself and everything below
+it. A `fullKey` set explicitly is always used as-is, even on a node with children,
+since the author chose that exact string on purpose.
+
+Compiling this (with `--tags typescript`) produces a standalone `Permissions.ts`
+with one exported const **per root permission** — not a single const wrapping the
+whole forest: each root's own `key`/`name`/`title`/`description` sit directly
+alongside one property per child (named by the child's own identifier), all
+flattened onto the same object, so you can navigate
+`ManagePostsPermission.createPost.key` with full editor autocomplete. Each literal
+is asserted `as const`, so TypeScript infers its whole shape straight from it — no
+separate type has to be hand-maintained in step with the tree. A root's own const
+name is always PascalCase with a trailing `Permission` (e.g. `name: managePosts` →
+`ManagePostsPermission`, `name: a` → `APermission`) — never the bare, lowercase
+child-style name — so a root reads unambiguously as a permission at a glance and two
+unrelated single-letter roots can't collide.
+
+Alongside each root const, a `<Name>PermissionList` const flattens that same root
+(and everything nested under it) into its own array — built by referencing the root
+const's own paths (e.g. `ManagePostsPermission.createPost`), not by re-declaring
+separate literals, so it can never drift out of sync with it (mirrors the
+`<Name>List` vars the Go compiler generates next to each root var). One list per
+root, not a single list combining every root — a module with several unrelated
+permission groups shouldn't force every caller to filter one combined list back down
+to the group it actually cares about. This is the only flattened form generated —
+there's no separate flat constant per node, since one would just be the same string
+reachable a second, disconnected way (and would collide whenever two unrelated roots
+happen to nest a child with the same name).
+
+```ts
+export const ManagePostsPermission = {
+  key: "post.*",
+  name: "managePosts",
+  title: { en: "Manage posts" },
+  description: { en: "Permissions related to blog posts" },
+  createPost: {
+    key: "post.create",
+    name: "createPost",
+    title: { en: "Create post" },
+  },
+  publishPost: {
+    key: "post.publish",
+    name: "publishPost",
+    title: { en: "Publish post" },
+  },
+} as const;
+
+export const ManagePostsPermissionList = [
+  ManagePostsPermission,
+  ManagePostsPermission.createPost,
+  ManagePostsPermission.publishPost,
+] as const;
+```
+
+A module with a second, unrelated root permission gets its own separate const right
+alongside it, e.g. `export const ViewReportsPermission = { key: "report", ... } as
+const;`, plus its own separate `ViewReportsPermissionList` — not folded into
+`ManagePostsPermissionList`.
+
+If a child's own identifier happens to collide with one of the reserved attribute
+names (`key`, `name`, `title`, `description` — e.g. a child literally named
+`key`), that attribute on the *parent* is emitted with a trailing `_` instead
+(`key_`) so nothing gets silently overwritten.
+
+Without `--tags typescript`, the same file is emitted as plain `Permissions.js`:
+`as const` is omitted, and each root const is wrapped in `Object.freeze(...)`
+instead, as a runtime guard against the tree being mutated after the fact.
+
+```js
+export const ManagePostsPermission = Object.freeze({
+  key: "post.*",
+  name: "managePosts",
+  title: { en: "Manage posts" },
+  description: { en: "Permissions related to blog posts" },
+  createPost: {
+    key: "post.create",
+    name: "createPost",
+    title: { en: "Create post" },
+  },
+  publishPost: {
+    key: "post.publish",
+    name: "publishPost",
+    title: { en: "Publish post" },
+  },
+});
+
+export const ManagePostsPermissionList = Object.freeze([
+  ManagePostsPermission,
+  ManagePostsPermission.createPost,
+  ManagePostsPermission.publishPost,
+]);
+```

--- a/examples/emi-web/src/content/docs/kotlin/kotlin-permissions.mdx
+++ b/examples/emi-web/src/content/docs/kotlin/kotlin-permissions.mdx
@@ -1,0 +1,117 @@
+---
+title: "Permissions"
+sidebar:
+  order: 20
+---
+
+A module can declare a `permissions:` tree — a nested set of access control
+permissions the module contributes. Each permission has a `key` (its slug in the
+generated identifier) and a `name` (a programmatic identifier the compiler uses to
+name the generated Kotlin object for it, e.g. `name: managePosts` generates
+`object ManagePostsPermission`). The identifier itself is either set explicitly via
+`fullKey:` or computed by the compiler as `{parent.fullKey}.{key}` while the module
+is preprocessed. If `key` is left empty too, it's normalized from `name` (e.g.
+`name: managePosts` with no `key` becomes `key: managePosts`).
+
+```yaml
+name: blog
+permissions:
+  - key: post
+    name: managePosts
+    title:
+      en: Manage posts
+    description:
+      en: Permissions related to blog posts
+    children:
+      - key: create
+        name: createPost
+        title:
+          en: Create post
+      - key: publish
+        name: publishPost
+        title:
+          en: Publish post
+```
+
+`post` gets no explicit `fullKey`, so the compiler derives one: `post`. Its children
+inherit that as their prefix, becoming `post.create` and `post.publish`. Because
+`post` groups children *and* left its key for the compiler to derive, its generated
+key gets a trailing `.*` — `post.*` — signaling it covers itself and everything below
+it. A `fullKey` set explicitly is always used as-is, even on a node with children,
+since the author chose that exact string on purpose.
+
+Compiling this produces `Permissions.kt`:
+
+- one exported `object` **per root permission** — not a single object wrapping the
+  whole forest, and no separate flat constant per node either — so your IDE can
+  autocomplete straight down it, e.g. `ManagePostsPermission.CreatePost.key`. A node
+  with children is a nested Kotlin `object` (Kotlin's idiomatic compile-time
+  singleton namespace): its own `key`/`name`/`title`/`description` sit directly on
+  it as `val`s, alongside one nested object/val per child (named by the child's own
+  identifier, PascalCase). A node with no children collapses to a plain `val`
+  holding a `Permission` instance directly. The self attributes are always
+  lowercase while every child is always PascalCase, so the two can never collide —
+  there's no case-collision escape hatch to reach for, unlike a language that
+  flattens both into the same casing convention. The root's own name is always
+  PascalCase with a trailing `Permission` (e.g. `managePosts` →
+  `ManagePostsPermission`), so it reads unambiguously as a permission and can't
+  collide with an unrelated single-letter root.
+- alongside each root, a `<Name>PermissionList: List<Permission>`: that root
+  permission and every one of its descendants, flattened into its own list, by
+  referencing each node's own `permission` val rather than re-declaring separate
+  literals, so it can never drift out of sync with it. One list per root, not a
+  single list combining every root — a module with several unrelated permission
+  groups shouldn't force every caller to filter one combined list back down to the
+  group it actually cares about.
+
+The `Permission` data class itself only holds a single node's own attributes — no
+`children` property — since the tree structure lives in the nested objects above,
+not in the data instances; it exists purely as the common type every node's
+`permission` val and every `<Name>PermissionList` entry share.
+
+```kotlin
+data class Permission(
+	val key: String,
+	val name: String,
+	val title: Map<String, String>? = null,
+	val description: Map<String, String>? = null
+)
+
+// ManagePostsPermission mirrors the "managePosts" permission node (and everything nested under it),
+// so it can be navigated directly, e.g. ManagePostsPermission.key.
+object ManagePostsPermission {
+	val key: String = "post.*"
+	val name: String = "managePosts"
+	val title: Map<String, String>? = mapOf("en" to "Manage posts")
+	val description: Map<String, String>? = mapOf("en" to "Permissions related to blog posts")
+	val permission: Permission = Permission(key = key, name = name, title = title, description = description)
+
+	val CreatePost: Permission = Permission(
+		key = "post.create",
+		name = "createPost",
+		title = mapOf("en" to "Create post"),
+		description = null
+	)
+
+	val PublishPost: Permission = Permission(
+		key = "post.publish",
+		name = "publishPost",
+		title = mapOf("en" to "Publish post"),
+		description = null
+	)
+}
+
+// ManagePostsPermissionList flattens ManagePostsPermission (and everything nested under it) into a single list,
+// for anything that wants to walk them all at once (seeding an ACL table,
+// rendering a permissions picker, ...).
+val ManagePostsPermissionList: List<Permission> = listOf(
+	ManagePostsPermission.permission,
+	ManagePostsPermission.CreatePost,
+	ManagePostsPermission.PublishPost,
+)
+```
+
+A module with a second, unrelated root permission (e.g. `viewReports`, with no
+children) gets its own separate `val ViewReportsPermission: Permission` and its own
+separate `ViewReportsPermissionList` right alongside it — not folded into
+`ManagePostsPermissionList`.

--- a/examples/emi-web/src/content/docs/swift/swift-permissions.mdx
+++ b/examples/emi-web/src/content/docs/swift/swift-permissions.mdx
@@ -1,0 +1,118 @@
+---
+title: "Permissions"
+sidebar:
+  order: 20
+---
+
+A module can declare a `permissions:` tree — a nested set of access control
+permissions the module contributes. Each permission has a `key` (its slug in the
+generated identifier) and a `name` (a programmatic identifier the compiler uses to
+name the generated Swift enum for it, e.g. `name: managePosts` generates
+`enum ManagePostsPermission`). The identifier itself is either set explicitly via
+`fullKey:` or computed by the compiler as `{parent.fullKey}.{key}` while the module
+is preprocessed. If `key` is left empty too, it's normalized from `name` (e.g.
+`name: managePosts` with no `key` becomes `key: managePosts`).
+
+```yaml
+name: blog
+permissions:
+  - key: post
+    name: managePosts
+    title:
+      en: Manage posts
+    description:
+      en: Permissions related to blog posts
+    children:
+      - key: create
+        name: createPost
+        title:
+          en: Create post
+      - key: publish
+        name: publishPost
+        title:
+          en: Publish post
+```
+
+`post` gets no explicit `fullKey`, so the compiler derives one: `post`. Its children
+inherit that as their prefix, becoming `post.create` and `post.publish`. Because
+`post` groups children *and* left its key for the compiler to derive, its generated
+key gets a trailing `.*` — `post.*` — signaling it covers itself and everything below
+it. A `fullKey` set explicitly is always used as-is, even on a node with children,
+since the author chose that exact string on purpose.
+
+Compiling this produces `Permissions.swift`:
+
+- one exported `enum` namespace **per root permission** — not a single enum
+  wrapping the whole forest, and no separate flat constant per node either — so
+  Xcode can autocomplete straight down it, e.g.
+  `ManagePostsPermission.CreatePost.key`. A node with children is a nested Swift
+  `enum` with no cases (Swift's idiomatic uninstantiable namespace): its own
+  `key`/`name`/`title`/`description` sit directly on it as `static let`s, alongside
+  one nested enum/let per child (named by the child's own identifier, PascalCase).
+  A node with no children collapses to a plain `let` (or, nested inside an enum,
+  `static let`) holding a `Permission` instance directly. The self attributes are
+  always lowercase while every child is always PascalCase, so the two can never
+  collide — there's no case-collision escape hatch to reach for, unlike a language
+  that flattens both into the same casing convention. The root's own name is always
+  PascalCase with a trailing `Permission` (e.g. `managePosts` →
+  `ManagePostsPermission`), so it reads unambiguously as a permission and can't
+  collide with an unrelated single-letter root.
+- alongside each root, a `<Name>PermissionList: [Permission]`: that root permission
+  and every one of its descendants, flattened into its own array, by referencing
+  each node's own `permission` static let rather than re-declaring separate
+  literals, so it can never drift out of sync with it. One list per root, not a
+  single list combining every root — a module with several unrelated permission
+  groups shouldn't force every caller to filter one combined list back down to the
+  group it actually cares about.
+
+The `Permission` struct itself only holds a single node's own attributes — no
+`children` property — since the tree structure lives in the nested enums above,
+not in the data instances; it exists purely as the common type every node's
+`permission` let and every `<Name>PermissionList` entry share.
+
+```swift
+struct Permission: Codable {
+	let key: String
+	let name: String
+	let title: [String: String]?
+	let description: [String: String]?
+}
+
+// ManagePostsPermission mirrors the "managePosts" permission node (and everything nested under it),
+// so it can be navigated directly, e.g. ManagePostsPermission.key.
+enum ManagePostsPermission {
+	static let key: String = "post.*"
+	static let name: String = "managePosts"
+	static let title: [String: String]? = ["en": "Manage posts"]
+	static let description: [String: String]? = ["en": "Permissions related to blog posts"]
+	static let permission: Permission = Permission(key: key, name: name, title: title, description: description)
+
+	static let CreatePost: Permission = Permission(
+		key: "post.create",
+		name: "createPost",
+		title: ["en": "Create post"],
+		description: nil
+	)
+
+	static let PublishPost: Permission = Permission(
+		key: "post.publish",
+		name: "publishPost",
+		title: ["en": "Publish post"],
+		description: nil
+	)
+}
+
+// ManagePostsPermissionList flattens ManagePostsPermission (and everything nested under it) into a single array,
+// for anything that wants to walk them all at once (seeding an ACL table,
+// rendering a permissions picker, ...).
+let ManagePostsPermissionList: [Permission] = [
+	ManagePostsPermission.permission,
+	ManagePostsPermission.CreatePost,
+	ManagePostsPermission.PublishPost,
+]
+```
+
+A module with a second, unrelated root permission (e.g. `viewReports`, with no
+children) gets its own separate `let ViewReportsPermission: Permission` and its own
+separate `ViewReportsPermissionList` right alongside it — not folded into
+`ManagePostsPermissionList`.

--- a/lib/core/Emi.go
+++ b/lib/core/Emi.go
@@ -50,6 +50,12 @@ type Emi struct {
 	// that are NOT compiled into output files. They exist only to be referenced
 	// by other parts of the module — most notably as capture sources.
 	Templates *EmiTemplate `yaml:"templates,omitempty" json:"templates,omitempty" jsonschema:"description=Reusable shape definitions (dtos, actions) that are not compiled. Available as capture sources."`
+
+	// Permissions define the tree of access control permissions this module contributes.
+	// Each node's FullKey is resolved during preprocessing to parent.FullKey + "." + Key
+	// when not set explicitly, then compiled into a usable Permissions constant/tree by
+	// each target backend (see lib/golang and lib/js).
+	Permissions []*EmiPermission `yaml:"permissions,omitempty" json:"permissions,omitempty" jsonschema:"description=Tree of access control permissions this module contributes. Compiled into a usable Permissions constant/tree per target language."`
 }
 
 func (x *Emi) ActionsAsList() []string {

--- a/lib/core/EmiPermission.go
+++ b/lib/core/EmiPermission.go
@@ -1,0 +1,167 @@
+package core
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// EmiPermission describes a single node in a module's permission tree. It is purely
+// declarative — the actual authorization check is left to whatever app consumes the
+// generated code — but the compiler still resolves FullKey for every node so the
+// generated Go/JS output exposes one stable, dotted identifier per permission that
+// downstream code (ACL/ABAC checks, seed scripts, a permissions picker UI, ...) can
+// reference directly, instead of everyone hand-rolling their own string concatenation.
+type EmiPermission struct {
+
+	// Name is the programmatic identifier of this permission, used by the compiler to
+	// name the generated constant/variable for it (e.g. Name: "name" generates
+	// NamePermission). Unlike Key, it does not need to be unique among siblings only -
+	// keep it unique across the whole module if you want every permission to get its
+	// own generated identifier.
+	Name string `yaml:"name,omitempty" json:"name,omitempty" jsonschema:"description=Programmatic identifier of this permission used to name the generated constant/variable (e.g. Name: 'name' generates NamePermission)."`
+
+	// Title is the human readable label of the permission, keyed by locale (e.g. en, fa).
+	Title map[string]string `yaml:"title,omitempty" json:"title,omitempty" jsonschema:"description=Human readable label of the permission, keyed by locale (e.g. en, fa)."`
+
+	// Description explains what granting this permission allows, keyed by locale.
+	Description map[string]string `yaml:"description,omitempty" json:"description,omitempty" jsonschema:"description=Explains what granting this permission allows, keyed by locale."`
+
+	// Key is the short identifier of this permission, unique among its siblings.
+	Key string `yaml:"key,omitempty" json:"key,omitempty" jsonschema:"description=Short identifier of this permission, unique among its siblings."`
+
+	// FullKey is the fully qualified, dot separated identifier of this permission. If left
+	// empty, the compiler computes it while preprocessing the module, as the parent's
+	// FullKey plus this Key (or just this Key for a root permission).
+	FullKey string `yaml:"fullKey,omitempty" json:"fullKey,omitempty" jsonschema:"description=Fully qualified dot separated identifier. If left empty it is computed as the parent FullKey plus this Key while the module is preprocessed."`
+
+	// Children are permissions nested under this one, inheriting its FullKey as their prefix.
+	Children []*EmiPermission `yaml:"children,omitempty" json:"children,omitempty" jsonschema:"description=Permissions nested under this one, inheriting its FullKey as their prefix."`
+
+	// autoFullKey records whether FullKey was left for the compiler to derive (true),
+	// as opposed to set explicitly in yaml (false). Set by ResolvePermissionFullKeys,
+	// consumed by EffectiveKey's wildcard-suffix decision. Unexported: internal
+	// bookkeeping, not part of the module schema.
+	autoFullKey bool
+}
+
+// ResolvePermissionFullKeys walks a permission tree in place and fills in FullKey for
+// every node that doesn't already define one explicitly, deriving it from the
+// parent's already-resolved FullKey and the node's own Key. Call with parentFullKey ""
+// for a module's root permissions (see Emi.Preprocess, which does exactly that).
+//
+// A node left with no Key at all (Key: "" in yaml) gets one normalized from its Name
+// first (e.g. Name: "managePosts" -> Key: "managePosts"), so FullKey always has
+// something to build on even when the author only bothered to set Name.
+//
+// Safe to call more than once: a node whose FullKey is already set (explicitly, or
+// resolved by an earlier pass) is left untouched.
+func ResolvePermissionFullKeys(permissions []*EmiPermission, parentFullKey string) {
+	for _, p := range permissions {
+		if p == nil {
+			continue
+		}
+
+		if p.Key == "" && p.Name != "" {
+			p.Key = ToLower(p.Name)
+		}
+
+		if p.FullKey == "" {
+			p.autoFullKey = true
+			if parentFullKey == "" {
+				p.FullKey = p.Key
+			} else {
+				p.FullKey = parentFullKey + "." + p.Key
+			}
+		}
+
+		ResolvePermissionFullKeys(p.Children, p.FullKey)
+	}
+}
+
+// permissionIdentifierPattern is what every generator's identifier for a permission
+// node - a Go struct field, a JS/TS property, a Kotlin/Swift constant, ... - is
+// required to match: a plain ASCII identifier, starting with a letter or
+// underscore and containing only letters, digits, and underscores. Nothing else
+// (spaces, dots, "@", a leading digit, ...) is guaranteed to compile in every
+// target language, and some of it (e.g. "@") would silently compile into a
+// different name than the one written, in whichever language happens to tolerate
+// it syntactically.
+var permissionIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// ValidatePermissionIdentifiers walks a permission tree and rejects any node whose
+// identifier - its Name, or its Key when Name is empty, since that's whichever the
+// generators actually use to derive a field/const/var name from (see
+// permissionIdentifier in lib/golang/go-permissions.go, jsPermissionIdentifier in
+// lib/js/js-permissions.go, and their Kotlin/Swift equivalents) - doesn't match
+// permissionIdentifierPattern. Call after ResolvePermissionFullKeys, so a node that
+// only set Name (no Key) has already had Key normalized from it and isn't flagged
+// twice for the same problem.
+func ValidatePermissionIdentifiers(permissions []*EmiPermission) error {
+	for _, p := range permissions {
+		if p == nil {
+			continue
+		}
+
+		id := p.Name
+		if id == "" {
+			id = p.Key
+		}
+
+		if id != "" && !permissionIdentifierPattern.MatchString(id) {
+			return fmt.Errorf(
+				"permission %q (fullKey %q) has an invalid identifier %q: a permission's name (or its key, when name is left empty) must start with a letter or underscore and contain only letters, digits, and underscores",
+				id, p.FullKey, id,
+			)
+		}
+
+		if err := ValidatePermissionIdentifiers(p.Children); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// EffectiveKey returns the single identifier generated code exposes for this
+// permission: FullKey normally, or FullKey with a trailing ".*" when this node
+// groups children and its FullKey was left for the compiler to derive - signaling
+// that the key covers this permission and everything below it. A FullKey set
+// explicitly in yaml is always used as-is, even on a node with children, since the
+// author chose that exact string on purpose.
+//
+// core.ResolvePermissionFullKeys must have already run (Emi.Preprocess does this for
+// every StringToEmi/StringToEmiForAction caller) so FullKey is populated.
+func (p *EmiPermission) EffectiveKey() string {
+	if p == nil {
+		return ""
+	}
+	if p.autoFullKey && len(p.Children) > 0 {
+		return p.FullKey + ".*"
+	}
+	return p.FullKey
+}
+
+// Flatten returns this permission and every descendant as a single flat slice, in
+// depth-first order (self, then children left to right).
+func (x *EmiPermission) Flatten() []*EmiPermission {
+	if x == nil {
+		return nil
+	}
+
+	items := []*EmiPermission{x}
+	for _, c := range x.Children {
+		items = append(items, c.Flatten()...)
+	}
+
+	return items
+}
+
+// FlattenPermissions runs Flatten across a whole forest of root permissions - the
+// shape module.Permissions actually is.
+func FlattenPermissions(permissions []*EmiPermission) []*EmiPermission {
+	items := []*EmiPermission{}
+	for _, p := range permissions {
+		items = append(items, p.Flatten()...)
+	}
+	return items
+}

--- a/lib/core/preprocess.go
+++ b/lib/core/preprocess.go
@@ -65,6 +65,11 @@ func (m *Emi) Preprocess() error {
 		v.Captures = nil
 	}
 
+	ResolvePermissionFullKeys(m.Permissions, "")
+	if err := ValidatePermissionIdentifiers(m.Permissions); err != nil {
+		return err
+	}
+
 	return runPreprocessHooks(m, globalPreprocessHooks)
 }
 

--- a/lib/golang/go-permissions.go
+++ b/lib/golang/go-permissions.go
@@ -1,0 +1,285 @@
+package golang
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/torabian/emi/lib/core"
+)
+
+// GoPermissionsGenerate renders the module's `permissions:` tree into a single
+// Permissions.go:
+//
+//   - one exported var per root permission - not a single var wrapping the whole
+//     forest - each a fully typed, nested anonymous struct. Every node embeds
+//     emigo.Permission and has one field per child, so an IDE can autocomplete
+//     straight down it (e.g. ManagePostsPermission.CreatePost.Key) with no
+//     map/string lookup and thus no risk of a typo'd key only failing at runtime -
+//     which is also why there's no flat per-node constant here the way JS/Kotlin/
+//     Swift have: with everything already reachable this way, a parallel
+//     `CreatePostPermission = "..."` would just be the same string under a
+//     second, disconnected name to keep in sync. The root var's own name is always
+//     PascalCase with a trailing "Permission" (see goRootPermissionName) - e.g.
+//     `managePosts` -> `ManagePostsPermission` - so it reads unambiguously as a
+//     permission and two unrelated single-letter roots can't collide.
+//   - alongside each root var, a <Name>PermissionList var: that root permission and
+//     every one of its descendants, flattened into its own []emigo.Permission (e.g.
+//     ManagePostsPermissionList, next to ManagePostsPermission) by referencing the
+//     root var's own fields (e.g. ManagePostsPermission.Permission,
+//     ManagePostsPermission.CreatePost) - not re-declared as separate literals - so
+//     it can never drift from them, for anything that wants to walk just that
+//     root's permissions at once (seeding an ACL table, rendering a permissions
+//     picker, ...). One list per root, not a single list combining every root, so a
+//     module with several unrelated permission groups doesn't force every caller to
+//     filter one combined list back down to the group it actually cares about.
+//
+// The Permission type itself is emigo.Permission (see emigo/Permission.go), not
+// redefined here - every generated Permissions.go across every module shares the
+// same type, instead of each one declaring its own incompatible copy.
+//
+// core.ResolvePermissionFullKeys must have already run (Emi.Preprocess does this for
+// every StringToEmi/StringToEmiForAction caller) so every node here already has
+// FullKey populated. Returns (nil, nil) when the module declares no permissions.
+func GoPermissionsGenerate(
+	permissions []*core.EmiPermission,
+	ctx core.MicroGenContext,
+	emigoImportPath string,
+) (*core.CodeChunkCompiled, error) {
+
+	if len(permissions) == 0 {
+		return nil, nil
+	}
+
+	rootVars := &strings.Builder{}
+	renderPermissionRootVars(rootVars, permissions)
+
+	const tmpl = `/**
+* Permission keys generated from the module's permissions tree.
+*/
+
+{{ .rootVars }}`
+
+	t := template.Must(template.New("permissions").Funcs(core.CommonMap).Parse(tmpl))
+
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, core.H{
+		"rootVars": rootVars.String(),
+	}); err != nil {
+		return nil, err
+	}
+
+	return &core.CodeChunkCompiled{
+		SuggestedFileName:  "Permissions",
+		SuggestedExtension: ".go",
+		ActualScript:       buf.Bytes(),
+		CodeChunkDependensies: []core.CodeChunkDependency{
+			{Location: emigoImportPath},
+		},
+	}, nil
+}
+
+// permissionIdentifier is the base identifier a permission is referred to by - its
+// Name when set, falling back to its Key (guaranteed unique among siblings, unlike
+// Name which is optional). Used to derive its struct/var field name.
+func permissionIdentifier(p *core.EmiPermission) string {
+	if p.Name != "" {
+		return p.Name
+	}
+	return p.Key
+}
+
+// permissionFieldName turns a permission's own identifier (its Name, falling back
+// to its Key) into the PascalCase Go struct field name for it (e.g. "createPost" ->
+// "CreatePost").
+func permissionFieldName(p *core.EmiPermission) string {
+	return core.ToUpper(permissionIdentifier(p))
+}
+
+// goPermissionLiteral renders a single node's own fields (Key/Name/Title/
+// Description) as an emigo.Permission{...} composite literal, with no Children -
+// used both as the leaf-node field value and embedded (as the promoted Permission
+// field) inside a branch node's own anonymous struct value. Each field gets its own
+// line rather than one long comma-separated line - gofmt only reflows a composite
+// literal onto multiple aligned lines when the source already breaks it that way,
+// so with Title/Description often being multi-entry maps, keeping this on one line
+// would leave some of these unreadably long once AsFullDocument's gofmt pass runs
+// over the file.
+func goPermissionLiteral(p *core.EmiPermission) string {
+	return fmt.Sprintf(
+		"emigo.Permission{\nKey: %q,\nName: %q,\nTitle: %s,\nDescription: %s,\n}",
+		p.EffectiveKey(), p.Name, goStringMapLiteral(p.Title), goStringMapLiteral(p.Description),
+	)
+}
+
+// selfPermissionFieldName returns the field name a node's own emigo.Permission
+// value is stored under within its generated struct: "" to embed it anonymously
+// (promoting Key/Name/... straight onto the node - the common case), or the
+// explicit name "Permission_" when one of its children happens to have that exact
+// field name ("Permission", the name Go gives an anonymous emigo.Permission field)
+// - embedding both would otherwise declare/initialize the same field name twice.
+func selfPermissionFieldName(p *core.EmiPermission) string {
+	for _, c := range p.Children {
+		if c != nil && permissionFieldName(c) == "Permission" {
+			return "Permission_"
+		}
+	}
+	return ""
+}
+
+// goPermissionNodeType returns the Go type of a permission node: plain
+// emigo.Permission for a leaf, or - for a node with children - a struct holding
+// emigo.Permission (so its own Key/... are promoted, unless selfPermissionFieldName
+// says a child's field name collides with that promotion, in which case it's given
+// an explicit, non-embedded name instead) plus one field per child, typed the same
+// way recursively. The struct itself is anonymous rather than named so two
+// permissions that happen to share a Name in different branches of the tree (an
+// alarm you can't get from a top-level type name, since Go requires those to be
+// package-unique) can never collide - there is no name to collide over.
+func goPermissionNodeType(p *core.EmiPermission, indent string) string {
+	if len(p.Children) == 0 {
+		return "emigo.Permission"
+	}
+
+	var b strings.Builder
+	b.WriteString("struct {\n")
+	if self := selfPermissionFieldName(p); self != "" {
+		fmt.Fprintf(&b, "%s\t%s emigo.Permission\n", indent+"\t", self)
+	} else {
+		fmt.Fprintf(&b, "%s\temigo.Permission\n", indent+"\t")
+	}
+	for _, c := range p.Children {
+		if c == nil {
+			continue
+		}
+		fmt.Fprintf(&b, "%s\t%s %s\n", indent+"\t", permissionFieldName(c), goPermissionNodeType(c, indent+"\t"))
+	}
+	fmt.Fprintf(&b, "%s}", indent)
+
+	return b.String()
+}
+
+// goPermissionNodeValue renders the composite literal for a permission node,
+// matching whatever goPermissionNodeType returned for it.
+func goPermissionNodeValue(p *core.EmiPermission, indent string) string {
+	if len(p.Children) == 0 {
+		return goPermissionLiteral(p)
+	}
+
+	selfField := "Permission"
+	if self := selfPermissionFieldName(p); self != "" {
+		selfField = self
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s{\n", goPermissionNodeType(p, indent))
+	fmt.Fprintf(&b, "%s\t%s: %s,\n", indent+"\t", selfField, goPermissionLiteral(p))
+	for _, c := range p.Children {
+		if c == nil {
+			continue
+		}
+		fmt.Fprintf(&b, "%s\t%s: %s,\n", indent+"\t", permissionFieldName(c), goPermissionNodeValue(c, indent+"\t"))
+	}
+	fmt.Fprintf(&b, "%s}", indent)
+
+	return b.String()
+}
+
+// goRootPermissionName turns a root permission's own identifier into its exported
+// var name (and, with "List" appended, its flattened slice's): PascalCase with a
+// trailing "Permission" always appended (e.g. "ali" -> "AliPermission",
+// "managePosts" -> "ManagePostsPermission") - unlike a nested child field, which
+// stays plain PascalCase with no suffix. Mirrors jsRootPermissionName in
+// lib/js/js-permissions.go, so a root permission reads unambiguously as one at a
+// glance in both languages.
+func goRootPermissionName(p *core.EmiPermission) string {
+	return permissionFieldName(p) + "Permission"
+}
+
+// renderPermissionRootVars renders, for each root permission, one exported var -
+// not a single wrapping var for the whole forest - a fully typed nested struct (or,
+// for a childless root, a plain emigo.Permission) so an IDE can autocomplete a path
+// straight down it, e.g. ManagePostsPermission.CreatePost.Key. Its name is always
+// PascalCase with a trailing "Permission" (see goRootPermissionName), so it reads
+// unambiguously as a permission and can't collide with an unrelated single-letter
+// root. Right alongside it, a <Name>PermissionList var flattens that same root (and
+// everything nested under it) into its own []emigo.Permission, by referencing the
+// var's own fields rather than re-declaring separate literals, so it can never
+// drift out of sync with it.
+func renderPermissionRootVars(w *strings.Builder, permissions []*core.EmiPermission) {
+	for _, p := range permissions {
+		if p == nil {
+			continue
+		}
+
+		name := goRootPermissionName(p)
+		fmt.Fprintf(w, "// %s mirrors the %q permission node (and everything nested under it),\n", name, permissionIdentifier(p))
+		fmt.Fprintf(w, "// so it can be navigated directly, e.g. %s.Key.\n", name)
+		fmt.Fprintf(w, "var %s = %s\n\n", name, goPermissionNodeValue(p, ""))
+
+		fmt.Fprintf(w, "// %sList flattens %s (and everything nested under it) into a single slice,\n", name, name)
+		fmt.Fprintf(w, "// for anything that wants to walk them all at once (seeding an ACL table,\n")
+		fmt.Fprintf(w, "// rendering a permissions picker, ...).\n")
+		fmt.Fprintf(w, "var %sList = []emigo.Permission{\n", name)
+		for _, path := range collectPermissionPaths(p, name) {
+			fmt.Fprintf(w, "\t%s,\n", path)
+		}
+		w.WriteString("}\n\n")
+	}
+}
+
+// collectPermissionPaths returns, for a single root permission var accessed under
+// varPath, the Go expression that refers to *this* node's own emigo.Permission
+// value (self first, in the same order goPermissionNodeValue emits fields),
+// followed recursively by every descendant's. A leaf is the var path itself (its
+// field is already emigo.Permission); a branch is varPath plus whatever field name
+// its own value was stored under (see selfPermissionFieldName).
+func collectPermissionPaths(p *core.EmiPermission, varPath string) []string {
+	if p == nil {
+		return nil
+	}
+
+	if len(p.Children) == 0 {
+		return []string{varPath}
+	}
+
+	selfField := "Permission"
+	if self := selfPermissionFieldName(p); self != "" {
+		selfField = self
+	}
+
+	paths := []string{varPath + "." + selfField}
+	for _, c := range p.Children {
+		if c == nil {
+			continue
+		}
+		paths = append(paths, collectPermissionPaths(c, varPath+"."+permissionFieldName(c))...)
+	}
+
+	return paths
+}
+
+// goStringMapLiteral renders a map[string]string as a Go literal, sorted by key so
+// the generated file is deterministic across runs.
+func goStringMapLiteral(m map[string]string) string {
+	if len(m) == 0 {
+		return "nil"
+	}
+
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	b.WriteString("map[string]string{")
+	for _, k := range keys {
+		fmt.Fprintf(&b, "%q: %q, ", k, m[k])
+	}
+	b.WriteString("}")
+
+	return b.String()
+}

--- a/lib/golang/go-public-api.go
+++ b/lib/golang/go-public-api.go
@@ -336,6 +336,19 @@ func GoModuleFull(module *core.Emi, ctx core.MicroGenContext) ([]core.VirtualFil
 		})
 	}
 
+	permissionsOutput, err := GoPermissionsGenerate(module.Permissions, ctx, f.Emigo)
+	if err != nil {
+		return nil, err
+	}
+
+	if permissionsOutput != nil {
+		files = append(files, core.VirtualFile{
+			Name:         permissionsOutput.SuggestedFileName,
+			Extension:    permissionsOutput.SuggestedExtension,
+			ActualScript: AsFullDocument(permissionsOutput, f.PackageName),
+		})
+	}
+
 	return files, nil
 }
 

--- a/lib/js/js-module.go
+++ b/lib/js/js-module.go
@@ -177,6 +177,19 @@ func JsModuleFullVirtualFiles(module *core.Emi, ctx core.MicroGenContext) ([]cor
 		})
 	}
 
+	if len(module.Permissions) > 0 {
+		permissionsRendered, err := JsStandalonePermissions(module.Permissions, ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		files = append(files, core.VirtualFile{
+			Name:         permissionsRendered.SuggestedFileName,
+			Extension:    permissionsRendered.SuggestedExtension,
+			ActualScript: AsFullDocument(permissionsRendered, ctx),
+		})
+	}
+
 	for _, remote := range module.Remotes {
 		if config.Remotes != nil && len(*config.Remotes) > 0 && !slices.Contains(config.GetRemotes(), remote.Name) {
 			continue

--- a/lib/js/js-permissions.go
+++ b/lib/js/js-permissions.go
@@ -1,0 +1,252 @@
+package js
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/torabian/emi/lib/core"
+)
+
+// jsPermissionIdentifier is the base identifier a permission is referred to by -
+// its Name when set, falling back to its Key (mirrors the Go generator's
+// permissionIdentifier in lib/golang/go-permissions.go, so both compilers name a
+// node the same way).
+func jsPermissionIdentifier(p *core.EmiPermission) string {
+	if p.Name != "" {
+		return p.Name
+	}
+	return p.Key
+}
+
+// jsPermissionFieldName turns a permission's own identifier into the camelCase
+// object-property name it's nested under in PermissionsTree (e.g. "createPost").
+func jsPermissionFieldName(p *core.EmiPermission) string {
+	return core.ToLower(jsPermissionIdentifier(p))
+}
+
+// jsRootPermissionName turns a root permission's own identifier into the exported
+// const name for its tree (and, with "List" appended, its flattened array): PascalCase
+// with a trailing "Permission" always appended (e.g. "managePosts" -> "ManagePostsPermission",
+// "a" -> "APermission"), so every root is unambiguously a permission at a glance and
+// two single-letter roots like "a" and "A" can't collide the way bare jsPermissionFieldName
+// output could.
+func jsRootPermissionName(p *core.EmiPermission) string {
+	return core.ToUpper(jsPermissionIdentifier(p)) + "Permission"
+}
+
+// jsSelfPropertyName returns the property name a node's own reserved self
+// attribute ("key", "name", "title", or "description") is emitted under: the
+// reserved name itself, or that name with a trailing "_" when a child happens to
+// have the exact same field name - which would otherwise silently overwrite it,
+// since a node's own attributes and its children are flattened onto one object.
+// Mirrors selfPermissionFieldName in lib/golang/go-permissions.go.
+func jsSelfPropertyName(reserved string, children []*core.EmiPermission) string {
+	for _, c := range children {
+		if c != nil && jsPermissionFieldName(c) == reserved {
+			return reserved + "_"
+		}
+	}
+	return reserved
+}
+
+// renderJsPermissionChildren renders one indent level of a permissions forest as
+// `<fieldName>: {...},` entries - used recursively for each node's own children
+// (the root level instead gets its own `export const <fieldName> = {...}`, one per
+// root permission, rendered by renderJsPermissionRootVars).
+func renderJsPermissionChildren(w *strings.Builder, permissions []*core.EmiPermission, indent string) {
+	for _, p := range permissions {
+		if p == nil {
+			continue
+		}
+
+		fmt.Fprintf(w, "%s%s: {\n", indent, jsPermissionFieldName(p))
+		renderJsPermissionNodeBody(w, p, indent+"\t")
+		fmt.Fprintf(w, "%s},\n", indent)
+	}
+}
+
+// renderJsPermissionNodeBody renders a single node's own key/name/title/description
+// (its "self" attributes) followed by one property per child - flattened onto the
+// same object, so managePosts.key and managePosts.createPost.key are both valid
+// paths off the same exported const.
+func renderJsPermissionNodeBody(w *strings.Builder, p *core.EmiPermission, indent string) {
+	fmt.Fprintf(w, "%s%s: %q,\n", indent, jsSelfPropertyName("key", p.Children), p.EffectiveKey())
+
+	if p.Name != "" {
+		fmt.Fprintf(w, "%s%s: %q,\n", indent, jsSelfPropertyName("name", p.Children), p.Name)
+	}
+	if len(p.Title) > 0 {
+		fmt.Fprintf(w, "%s%s: %s,\n", indent, jsSelfPropertyName("title", p.Children), jsStringMapLiteral(p.Title))
+	}
+	if len(p.Description) > 0 {
+		fmt.Fprintf(w, "%s%s: %s,\n", indent, jsSelfPropertyName("description", p.Children), jsStringMapLiteral(p.Description))
+	}
+
+	renderJsPermissionChildren(w, p.Children, indent)
+}
+
+// renderJsPermissionRootVars renders one exported const per root permission - not a
+// single wrapping const for the whole forest - each one the node's own flattened
+// key/name/title/description plus one property per child, so consumers can
+// navigate e.g. ManagePostsPermission.createPost.key directly. Its name is always
+// PascalCase with a trailing "Permission" (see jsRootPermissionName) - not the plain
+// camelCase used for a nested child field - so a root is recognizable as a
+// permission on sight and can't collide with an unrelated single-letter root. In
+// TypeScript the literal is asserted `as const` so its shape is inferred precisely;
+// in plain JS (no such assertion exists) it's wrapped in Object.freeze(...) instead,
+// as a runtime guard against the tree being mutated after the fact.
+//
+// Right alongside each root const, a <Name>PermissionList const flattens that same
+// root (and everything nested under it) into its own array, by referencing the root
+// const's own paths (e.g. ManagePostsPermission.createPost) rather than re-declaring
+// separate literals, so it can never drift out of sync with it - mirroring the
+// <Name>List vars lib/golang/go-permissions.go generates next to each root var. One
+// list per root, not a single list combining every root, so a module with several
+// unrelated permission groups doesn't force every caller to filter one combined list
+// back down to the group it actually cares about.
+func renderJsPermissionRootVars(w *strings.Builder, permissions []*core.EmiPermission, isTypeScript bool) {
+	for _, p := range permissions {
+		if p == nil {
+			continue
+		}
+
+		name := jsRootPermissionName(p)
+		if isTypeScript {
+			fmt.Fprintf(w, "export const %s = {\n", name)
+			renderJsPermissionNodeBody(w, p, "\t")
+			w.WriteString("} as const;\n\n")
+		} else {
+			fmt.Fprintf(w, "export const %s = Object.freeze({\n", name)
+			renderJsPermissionNodeBody(w, p, "\t")
+			w.WriteString("});\n\n")
+		}
+
+		paths := collectJsPermissionPaths(p, name)
+		if isTypeScript {
+			fmt.Fprintf(w, "export const %sList = [\n", name)
+			for _, path := range paths {
+				fmt.Fprintf(w, "\t%s,\n", path)
+			}
+			w.WriteString("] as const;\n\n")
+		} else {
+			fmt.Fprintf(w, "export const %sList = Object.freeze([\n", name)
+			for _, path := range paths {
+				fmt.Fprintf(w, "\t%s,\n", path)
+			}
+			w.WriteString("]);\n\n")
+		}
+	}
+}
+
+// collectJsPermissionPaths returns, for a single root permission const accessed
+// under varPath, the JS expression that refers to *this* node itself (its own
+// key/name/title/description already sit directly on it, unlike Go's separate
+// embedded Permission field, so there's no extra suffix for the self entry),
+// followed recursively by every descendant's, in the same order
+// renderJsPermissionNodeBody emits properties.
+func collectJsPermissionPaths(p *core.EmiPermission, varPath string) []string {
+	if p == nil {
+		return nil
+	}
+
+	paths := []string{varPath}
+	for _, c := range p.Children {
+		if c == nil {
+			continue
+		}
+		paths = append(paths, collectJsPermissionPaths(c, varPath+"."+jsPermissionFieldName(c))...)
+	}
+
+	return paths
+}
+
+// jsStringMapLiteral renders a map[string]string as a JS object literal, sorted by
+// key so the generated file is deterministic across runs.
+func jsStringMapLiteral(m map[string]string) string {
+	if len(m) == 0 {
+		return "{}"
+	}
+
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	b.WriteString("{ ")
+	for _, k := range keys {
+		fmt.Fprintf(&b, "%q: %q, ", k, m[k])
+	}
+	b.WriteString("}")
+
+	return b.String()
+}
+
+// JsStandalonePermissions renders the module's `permissions:` tree into a single
+// standalone JS/TS file:
+//
+//   - one exported const per root permission - not a single const wrapping the
+//     whole forest - each one a flattened, nested object literal: the node's own
+//     key/name/title/description sit directly alongside one property per child
+//     (named by the child's own identifier), so consumers can navigate e.g.
+//     ManagePostsPermission.createPost.key with full IDE autocomplete. Its name is
+//     always PascalCase with a trailing "Permission" (see jsRootPermissionName), so
+//     a root reads unambiguously as a permission and can't collide with an
+//     unrelated single-letter root. In TypeScript each literal is asserted
+//     `as const`, so its whole shape is inferred directly - no separate type needs
+//     to be hand maintained in step with the tree (mirrors the per-root vars in
+//     lib/golang/go-permissions.go, translated to what TS's structural type system
+//     does for free instead of Go's explicit anonymous structs)
+//   - alongside each root const, a <Name>PermissionList const: that root permission
+//     and every one of its descendants, flattened into its own array (e.g.
+//     ManagePostsPermissionList, next to ManagePostsPermission) by referencing the
+//     root const's own paths (e.g. ManagePostsPermission, ManagePostsPermission.createPost)
+//   - not re-declared as separate literals - so it can never drift from it. One
+//     list per root, not a single list combining every root (mirrors <Name>List in
+//     lib/golang/go-permissions.go). This is the only flattened form generated -
+//     there is no separate flat constant per node, since one would just be the same
+//     string reachable a second, disconnected way.
+//
+// core.ResolvePermissionFullKeys must have already run (Emi.Preprocess does this for
+// every StringToEmi caller) so every node here already has its key populated.
+func JsStandalonePermissions(
+	permissions []*core.EmiPermission,
+	ctx core.MicroGenContext,
+) (*core.CodeChunkCompiled, error) {
+
+	isTypeScript := ctx.HasTag(Typescript)
+
+	rootVars := &strings.Builder{}
+	renderJsPermissionRootVars(rootVars, permissions, isTypeScript)
+
+	const tmpl = `/**
+* Permission keys generated from the module's permissions tree.
+*/
+
+{{ .rootVars }}`
+
+	t := template.Must(template.New("permissions").Funcs(core.CommonMap).Parse(tmpl))
+
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, core.H{
+		"rootVars": rootVars.String(),
+	}); err != nil {
+		return nil, err
+	}
+
+	res := &core.CodeChunkCompiled{
+		SuggestedFileName: "Permissions",
+		ActualScript:      buf.Bytes(),
+	}
+
+	res.SuggestedExtension = ".js"
+	if isTypeScript {
+		res.SuggestedExtension = ".ts"
+	}
+
+	return res, nil
+}

--- a/lib/kotlin/kotlin-permissions.go
+++ b/lib/kotlin/kotlin-permissions.go
@@ -1,0 +1,237 @@
+package kotlin
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/torabian/emi/lib/core"
+)
+
+// KotlinPermissionsGenerate renders the module's `permissions:` tree into a single
+// Permissions.kt:
+//
+//   - one exported object (or, for a childless root, a plain val) per root
+//     permission - not a single object wrapping the whole forest - so IDEs can
+//     autocomplete straight down it, e.g. ManagePostsPermission.CreatePost.key. A
+//     node with children is a nested Kotlin `object` (Kotlin's idiomatic
+//     compile-time singleton namespace): its own key/name/title/description sit
+//     directly on it as vals, alongside one nested object/val per child (named by
+//     the child's own identifier, PascalCase). A node with no children is instead a
+//     plain `val` holding a Permission instance directly. The self attributes are
+//     always lowercase (key, name, title, description) while every child is always
+//     PascalCase, so the two can never collide the way JS's flattened object (where
+//     both live in the same, single-case namespace) needs a "_" escape for -
+//     nothing here needs one. The root's own name is always PascalCase with a
+//     trailing "Permission" (see kotlinRootPermissionName), e.g. `managePosts` ->
+//     `ManagePostsPermission`, so it reads unambiguously as a permission and can't
+//     collide with an unrelated single-letter root (mirrors the Go/JS generators).
+//   - alongside each root, a `val <Name>PermissionList: List<Permission>`: that root
+//     permission and every one of its descendants, flattened into its own list, by
+//     referencing each node's own `permission` val (its own key/name/title/
+//     description composed into a Permission instance) rather than re-declaring
+//     separate literals, so it can never drift out of sync with it. One list per
+//     root, not a single list combining every root, so a module with several
+//     unrelated permission groups doesn't force every caller to filter one combined
+//     list back down to the group it actually cares about.
+//
+// The Permission data class itself only holds a single node's own attributes - no
+// Children field - since the tree structure lives in the nested objects above, not
+// in the data instances; the data class exists purely as the common type every
+// node's `permission` val and every `<Name>PermissionList` entry share.
+//
+// core.ResolvePermissionFullKeys must have already run (Emi.Preprocess does this for
+// every StringToEmi/StringToEmiForAction caller) so every node here already has
+// FullKey populated. Returns (nil, nil) when the module declares no permissions.
+func KotlinPermissionsGenerate(
+	permissions []*core.EmiPermission,
+	ctx core.MicroGenContext,
+) (*core.CodeChunkCompiled, error) {
+
+	if len(permissions) == 0 {
+		return nil, nil
+	}
+
+	rootVars := &strings.Builder{}
+	renderKotlinPermissionRootVars(rootVars, permissions)
+
+	const tmpl = `/**
+* Permission keys generated from the module's permissions tree.
+*/
+
+data class Permission(
+	val key: String,
+	val name: String,
+	val title: Map<String, String>? = null,
+	val description: Map<String, String>? = null
+)
+
+{{ .rootVars }}`
+
+	t := template.Must(template.New("permissions").Funcs(core.CommonMap).Parse(tmpl))
+
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, core.H{
+		"rootVars": rootVars.String(),
+	}); err != nil {
+		return nil, err
+	}
+
+	return &core.CodeChunkCompiled{
+		SuggestedFileName:  "Permissions",
+		SuggestedExtension: ".kt",
+		ActualScript:       buf.Bytes(),
+	}, nil
+}
+
+// kotlinPermissionIdentifier is the base identifier a permission is referred to by -
+// its Name when set, falling back to its Key (mirrors permissionIdentifier in
+// lib/golang/go-permissions.go and jsPermissionIdentifier in
+// lib/js/js-permissions.go, so every compiler names a node the same way).
+func kotlinPermissionIdentifier(p *core.EmiPermission) string {
+	if p.Name != "" {
+		return p.Name
+	}
+	return p.Key
+}
+
+// kotlinChildName turns a permission's own identifier into the PascalCase Kotlin
+// object/val name it's nested under (e.g. "createPost" -> "CreatePost").
+func kotlinChildName(p *core.EmiPermission) string {
+	return core.ToUpper(kotlinPermissionIdentifier(p))
+}
+
+// kotlinRootPermissionName turns a root permission's own identifier into its
+// exported name (and, with "List" appended, its flattened list's): PascalCase with
+// a trailing "Permission" always appended (e.g. "managePosts" ->
+// "ManagePostsPermission") - unlike a nested child, which stays plain PascalCase
+// with no suffix. Mirrors goRootPermissionName in lib/golang/go-permissions.go and
+// jsRootPermissionName in lib/js/js-permissions.go.
+func kotlinRootPermissionName(p *core.EmiPermission) string {
+	return kotlinChildName(p) + "Permission"
+}
+
+// kotlinPermissionLiteral renders a single node's own fields as a Permission(...)
+// constructor call, each field on its own line for readability once Title/
+// Description are multi-entry maps (mirrors goPermissionLiteral in
+// lib/golang/go-permissions.go).
+func kotlinPermissionLiteral(p *core.EmiPermission, indent string) string {
+	return fmt.Sprintf(
+		"Permission(\n%s\tkey = %q,\n%s\tname = %q,\n%s\ttitle = %s,\n%s\tdescription = %s\n%s)",
+		indent, p.EffectiveKey(),
+		indent, p.Name,
+		indent, kotlinStringMapLiteral(p.Title),
+		indent, kotlinStringMapLiteral(p.Description),
+		indent,
+	)
+}
+
+// renderKotlinPermissionNode renders a single node under the given name: a plain
+// `val <name>: Permission = Permission(...)` for a leaf, or a nested
+// `object <name> { ... }` - its own key/name/title/description as vals, a
+// `permission` val composing them into a Permission instance, then one nested
+// object/val per child - for a node with children.
+func renderKotlinPermissionNode(w *strings.Builder, name string, p *core.EmiPermission, indent string) {
+	if len(p.Children) == 0 {
+		fmt.Fprintf(w, "%sval %s: Permission = %s\n", indent, name, kotlinPermissionLiteral(p, indent))
+		return
+	}
+
+	fmt.Fprintf(w, "%sobject %s {\n", indent, name)
+
+	childIndent := indent + "\t"
+	fmt.Fprintf(w, "%sval key: String = %q\n", childIndent, p.EffectiveKey())
+	fmt.Fprintf(w, "%sval name: String = %q\n", childIndent, p.Name)
+	fmt.Fprintf(w, "%sval title: Map<String, String>? = %s\n", childIndent, kotlinStringMapLiteral(p.Title))
+	fmt.Fprintf(w, "%sval description: Map<String, String>? = %s\n", childIndent, kotlinStringMapLiteral(p.Description))
+	fmt.Fprintf(w, "%sval permission: Permission = Permission(key = key, name = name, title = title, description = description)\n", childIndent)
+
+	for _, c := range p.Children {
+		if c == nil {
+			continue
+		}
+		w.WriteString("\n")
+		renderKotlinPermissionNode(w, kotlinChildName(c), c, childIndent)
+	}
+
+	fmt.Fprintf(w, "%s}\n", indent)
+}
+
+// renderKotlinPermissionRootVars renders, for each root permission, one exported
+// object (or plain val, for a childless root) - not a single object wrapping the
+// whole forest - named PascalCase with a trailing "Permission" (see
+// kotlinRootPermissionName). Right alongside it, a `<Name>PermissionList` val
+// flattens that same root (and everything nested under it) into its own
+// List<Permission>, by referencing each node's own `permission` val rather than
+// re-declaring separate literals, so it can never drift out of sync with it.
+func renderKotlinPermissionRootVars(w *strings.Builder, permissions []*core.EmiPermission) {
+	for _, p := range permissions {
+		if p == nil {
+			continue
+		}
+
+		name := kotlinRootPermissionName(p)
+		fmt.Fprintf(w, "// %s mirrors the %q permission node (and everything nested under it),\n", name, kotlinPermissionIdentifier(p))
+		fmt.Fprintf(w, "// so it can be navigated directly, e.g. %s.key.\n", name)
+		renderKotlinPermissionNode(w, name, p, "")
+		w.WriteString("\n")
+
+		fmt.Fprintf(w, "// %sList flattens %s (and everything nested under it) into a single list,\n", name, name)
+		fmt.Fprintf(w, "// for anything that wants to walk them all at once (seeding an ACL table,\n")
+		fmt.Fprintf(w, "// rendering a permissions picker, ...).\n")
+		fmt.Fprintf(w, "val %sList: List<Permission> = listOf(\n", name)
+		for _, path := range collectKotlinPermissionPaths(p, name) {
+			fmt.Fprintf(w, "\t%s,\n", path)
+		}
+		w.WriteString(")\n\n")
+	}
+}
+
+// collectKotlinPermissionPaths returns, for a single root permission accessed under
+// varPath, the Kotlin expression that refers to *this* node's own Permission
+// instance (self first, then recursively each descendant's, in the same order
+// renderKotlinPermissionNode emits them). A leaf's own val already is that
+// Permission instance; a branch's is its nested object's `permission` val. Mirrors
+// collectPermissionPaths in lib/golang/go-permissions.go.
+func collectKotlinPermissionPaths(p *core.EmiPermission, varPath string) []string {
+	if p == nil {
+		return nil
+	}
+
+	if len(p.Children) == 0 {
+		return []string{varPath}
+	}
+
+	paths := []string{varPath + ".permission"}
+	for _, c := range p.Children {
+		if c == nil {
+			continue
+		}
+		paths = append(paths, collectKotlinPermissionPaths(c, varPath+"."+kotlinChildName(c))...)
+	}
+
+	return paths
+}
+
+// kotlinStringMapLiteral renders a map[string]string as a Kotlin mapOf(...) literal,
+// sorted by key so the generated file is deterministic across runs.
+func kotlinStringMapLiteral(m map[string]string) string {
+	if len(m) == 0 {
+		return "null"
+	}
+
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	pairs := make([]string, 0, len(keys))
+	for _, k := range keys {
+		pairs = append(pairs, fmt.Sprintf("%q to %q", k, m[k]))
+	}
+
+	return "mapOf(" + strings.Join(pairs, ", ") + ")"
+}

--- a/lib/kotlin/kotlin-public-api.go
+++ b/lib/kotlin/kotlin-public-api.go
@@ -225,6 +225,19 @@ func KotlinModuleFull(module *core.Emi, ctx core.MicroGenContext) ([]core.Virtua
 		})
 	}
 
+	permissionsOutput, err := KotlinPermissionsGenerate(module.Permissions, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if permissionsOutput != nil {
+		files = append(files, core.VirtualFile{
+			Name:         permissionsOutput.SuggestedFileName,
+			Extension:    permissionsOutput.SuggestedExtension,
+			ActualScript: AsFullDocument(permissionsOutput, pkgName),
+		})
+	}
+
 	// Append the sdk include files - skippable via --tags no-sdk when another `emi
 	// kotlin` invocation into the same compilation unit already provides them (see
 	// CompilerTags in kotlin-compiler-tags.go).

--- a/lib/swift/swift-permissions.go
+++ b/lib/swift/swift-permissions.go
@@ -1,0 +1,247 @@
+package swift
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/torabian/emi/lib/core"
+)
+
+// SwiftPermissionsGenerate renders the module's `permissions:` tree into a single
+// Permissions.swift:
+//
+//   - one exported enum namespace (or, for a childless root, a plain let) per root
+//     permission - not a single enum wrapping the whole forest - so Xcode can
+//     autocomplete straight down it, e.g. ManagePostsPermission.CreatePost.key. A
+//     node with children is a nested Swift `enum` with no cases - Swift's idiomatic
+//     uninstantiable namespace - holding its own key/name/title/description as
+//     `static let`s, alongside one nested enum/let per child (named by the child's
+//     own identifier, PascalCase). A node with no children is instead a plain `let`
+//     holding a Permission instance directly. The self attributes are always
+//     lowercase (key, name, title, description) while every child is always
+//     PascalCase, so the two can never collide the way JS's flattened object (where
+//     both live in the same, single-case namespace) needs a "_" escape for -
+//     nothing here needs one. The root's own name is always PascalCase with a
+//     trailing "Permission" (see swiftRootPermissionName), e.g. `managePosts` ->
+//     `ManagePostsPermission`, so it reads unambiguously as a permission and can't
+//     collide with an unrelated single-letter root (mirrors the Go/Kotlin/JS
+//     generators).
+//   - alongside each root, a `let <Name>PermissionList: [Permission]`: that root
+//     permission and every one of its descendants, flattened into its own array, by
+//     referencing each node's own `permission` static let (its own key/name/title/
+//     description composed into a Permission instance) rather than re-declaring
+//     separate literals, so it can never drift out of sync with it. One list per
+//     root, not a single list combining every root, so a module with several
+//     unrelated permission groups doesn't force every caller to filter one combined
+//     list back down to the group it actually cares about.
+//
+// The Permission struct itself only holds a single node's own attributes - no
+// children property - since the tree structure lives in the nested enums above, not
+// in the data instances; the struct exists purely as the common type every node's
+// `permission` let and every `<Name>PermissionList` entry share.
+//
+// core.ResolvePermissionFullKeys must have already run (Emi.Preprocess does this for
+// every StringToEmi/StringToEmiForAction caller) so every node here already has
+// FullKey populated. Returns (nil, nil) when the module declares no permissions.
+func SwiftPermissionsGenerate(
+	permissions []*core.EmiPermission,
+	ctx core.MicroGenContext,
+) (*core.CodeChunkCompiled, error) {
+
+	if len(permissions) == 0 {
+		return nil, nil
+	}
+
+	rootVars := &strings.Builder{}
+	renderSwiftPermissionRootVars(rootVars, permissions)
+
+	const tmpl = `/**
+* Permission keys generated from the module's permissions tree.
+*/
+
+struct Permission: Codable {
+	let key: String
+	let name: String
+	let title: [String: String]?
+	let description: [String: String]?
+}
+
+{{ .rootVars }}`
+
+	t := template.Must(template.New("permissions").Funcs(core.CommonMap).Parse(tmpl))
+
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, core.H{
+		"rootVars": rootVars.String(),
+	}); err != nil {
+		return nil, err
+	}
+
+	return &core.CodeChunkCompiled{
+		SuggestedFileName:  "Permissions",
+		SuggestedExtension: ".swift",
+		ActualScript:       buf.Bytes(),
+	}, nil
+}
+
+// swiftPermissionIdentifier is the base identifier a permission is referred to by -
+// its Name when set, falling back to its Key (mirrors permissionIdentifier in
+// lib/golang/go-permissions.go and jsPermissionIdentifier in
+// lib/js/js-permissions.go, so every compiler names a node the same way).
+func swiftPermissionIdentifier(p *core.EmiPermission) string {
+	if p.Name != "" {
+		return p.Name
+	}
+	return p.Key
+}
+
+// swiftChildName turns a permission's own identifier into the PascalCase Swift
+// enum/let name it's nested under (e.g. "createPost" -> "CreatePost").
+func swiftChildName(p *core.EmiPermission) string {
+	return core.ToUpper(swiftPermissionIdentifier(p))
+}
+
+// swiftRootPermissionName turns a root permission's own identifier into its
+// exported name (and, with "List" appended, its flattened array's): PascalCase with
+// a trailing "Permission" always appended (e.g. "managePosts" ->
+// "ManagePostsPermission") - unlike a nested child, which stays plain PascalCase
+// with no suffix. Mirrors goRootPermissionName in lib/golang/go-permissions.go and
+// jsRootPermissionName in lib/js/js-permissions.go.
+func swiftRootPermissionName(p *core.EmiPermission) string {
+	return swiftChildName(p) + "Permission"
+}
+
+// swiftPermissionLiteral renders a single node's own fields as a Permission(...)
+// initializer call, each field on its own line for readability once title/
+// description are multi-entry dictionaries (mirrors goPermissionLiteral in
+// lib/golang/go-permissions.go).
+func swiftPermissionLiteral(p *core.EmiPermission, indent string) string {
+	return fmt.Sprintf(
+		"Permission(\n%s\tkey: %q,\n%s\tname: %q,\n%s\ttitle: %s,\n%s\tdescription: %s\n%s)",
+		indent, p.EffectiveKey(),
+		indent, p.Name,
+		indent, swiftStringMapLiteral(p.Title),
+		indent, swiftStringMapLiteral(p.Description),
+		indent,
+	)
+}
+
+// renderSwiftPermissionNode renders a single node under the given name: for a leaf,
+// a `let <name>: Permission = Permission(...)` (root/file scope) or
+// `static let <name>: Permission = Permission(...)` (nested inside an enum
+// namespace - Swift enums can't hold instance-stored properties); or, for a node
+// with children, a nested `enum <name> { ... }` - its own key/name/title/
+// description as `static let`s, a `permission` static let composing them into a
+// Permission instance, then one nested enum/let per child.
+func renderSwiftPermissionNode(w *strings.Builder, name string, p *core.EmiPermission, indent string) {
+	if len(p.Children) == 0 {
+		// A file-scope root (indent == "") is a plain `let`; nested inside an enum
+		// namespace it must be `static let` - Swift enums can't hold instance-stored
+		// properties, only static ones.
+		keyword := "let"
+		if indent != "" {
+			keyword = "static let"
+		}
+		fmt.Fprintf(w, "%s%s %s: Permission = %s\n", indent, keyword, name, swiftPermissionLiteral(p, indent))
+		return
+	}
+
+	fmt.Fprintf(w, "%senum %s {\n", indent, name)
+
+	childIndent := indent + "\t"
+	fmt.Fprintf(w, "%sstatic let key: String = %q\n", childIndent, p.EffectiveKey())
+	fmt.Fprintf(w, "%sstatic let name: String = %q\n", childIndent, p.Name)
+	fmt.Fprintf(w, "%sstatic let title: [String: String]? = %s\n", childIndent, swiftStringMapLiteral(p.Title))
+	fmt.Fprintf(w, "%sstatic let description: [String: String]? = %s\n", childIndent, swiftStringMapLiteral(p.Description))
+	fmt.Fprintf(w, "%sstatic let permission: Permission = Permission(key: key, name: name, title: title, description: description)\n", childIndent)
+
+	for _, c := range p.Children {
+		if c == nil {
+			continue
+		}
+		w.WriteString("\n")
+		renderSwiftPermissionNode(w, swiftChildName(c), c, childIndent)
+	}
+
+	fmt.Fprintf(w, "%s}\n", indent)
+}
+
+// renderSwiftPermissionRootVars renders, for each root permission, one exported enum
+// (or plain let, for a childless root) - not a single enum wrapping the whole
+// forest - named PascalCase with a trailing "Permission" (see
+// swiftRootPermissionName). Right alongside it, a `<Name>PermissionList` let
+// flattens that same root (and everything nested under it) into its own
+// [Permission], by referencing each node's own `permission` static let rather than
+// re-declaring separate literals, so it can never drift out of sync with it.
+func renderSwiftPermissionRootVars(w *strings.Builder, permissions []*core.EmiPermission) {
+	for _, p := range permissions {
+		if p == nil {
+			continue
+		}
+
+		name := swiftRootPermissionName(p)
+		fmt.Fprintf(w, "// %s mirrors the %q permission node (and everything nested under it),\n", name, swiftPermissionIdentifier(p))
+		fmt.Fprintf(w, "// so it can be navigated directly, e.g. %s.key.\n", name)
+		renderSwiftPermissionNode(w, name, p, "")
+		w.WriteString("\n")
+
+		fmt.Fprintf(w, "// %sList flattens %s (and everything nested under it) into a single array,\n", name, name)
+		fmt.Fprintf(w, "// for anything that wants to walk them all at once (seeding an ACL table,\n")
+		fmt.Fprintf(w, "// rendering a permissions picker, ...).\n")
+		fmt.Fprintf(w, "let %sList: [Permission] = [\n", name)
+		for _, path := range collectSwiftPermissionPaths(p, name) {
+			fmt.Fprintf(w, "\t%s,\n", path)
+		}
+		w.WriteString("]\n\n")
+	}
+}
+
+// collectSwiftPermissionPaths returns, for a single root permission accessed under
+// varPath, the Swift expression that refers to *this* node's own Permission
+// instance (self first, then recursively each descendant's, in the same order
+// renderSwiftPermissionNode emits them). A leaf's own let already is that
+// Permission instance; a branch's is its nested enum's `permission` static let.
+// Mirrors collectPermissionPaths in lib/golang/go-permissions.go.
+func collectSwiftPermissionPaths(p *core.EmiPermission, varPath string) []string {
+	if p == nil {
+		return nil
+	}
+
+	if len(p.Children) == 0 {
+		return []string{varPath}
+	}
+
+	paths := []string{varPath + ".permission"}
+	for _, c := range p.Children {
+		if c == nil {
+			continue
+		}
+		paths = append(paths, collectSwiftPermissionPaths(c, varPath+"."+swiftChildName(c))...)
+	}
+
+	return paths
+}
+
+// swiftStringMapLiteral renders a map[string]string as a Swift dictionary literal,
+// sorted by key so the generated file is deterministic across runs.
+func swiftStringMapLiteral(m map[string]string) string {
+	if len(m) == 0 {
+		return "nil"
+	}
+
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	pairs := make([]string, 0, len(keys))
+	for _, k := range keys {
+		pairs = append(pairs, fmt.Sprintf("%q: %q", k, m[k]))
+	}
+
+	return "[" + strings.Join(pairs, ", ") + "]"
+}

--- a/lib/swift/swift-public-api.go
+++ b/lib/swift/swift-public-api.go
@@ -195,6 +195,19 @@ func SwiftFullModule(module *core.Emi, ctx core.MicroGenContext) ([]core.Virtual
 		})
 	}
 
+	permissionsOutput, err := SwiftPermissionsGenerate(module.Permissions, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if permissionsOutput != nil {
+		files = append(files, core.VirtualFile{
+			Name:         permissionsOutput.SuggestedFileName,
+			Extension:    permissionsOutput.SuggestedExtension,
+			ActualScript: AsFullDocument(permissionsOutput, "unknownpackage"),
+		})
+	}
+
 	files = append(files, SwiftAnyCodableFile())
 	files = append(files, SwiftClientConfigFile())
 	files = append(files, SwiftWebSocketRuntimeFile())

--- a/playground/public/emi-module-spec.json
+++ b/playground/public/emi-module-spec.json
@@ -94,6 +94,13 @@
         "templates": {
           "$ref": "#/definitions/EmiTemplate",
           "description": "Reusable shape definitions (dtos"
+        },
+        "permissions": {
+          "items": {
+            "$ref": "#/definitions/EmiPermission"
+          },
+          "type": "array",
+          "description": "Tree of access control permissions this module contributes. Compiled into a usable Permissions constant/tree per target language."
         }
       },
       "additionalProperties": false,
@@ -637,6 +644,45 @@
       "required": [
         "name"
       ]
+    },
+    "EmiPermission": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Programmatic identifier of this permission used to name the generated constant/variable (e.g. Name: 'name' generates NamePermission)."
+        },
+        "title": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Human readable label of the permission"
+        },
+        "description": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Explains what granting this permission allows"
+        },
+        "key": {
+          "type": "string",
+          "description": "Short identifier of this permission"
+        },
+        "fullKey": {
+          "type": "string",
+          "description": "Fully qualified dot separated identifier. If left empty it is computed as the parent FullKey plus this Key while the module is preprocessed."
+        },
+        "children": {
+          "items": {
+            "$ref": "#/definitions/EmiPermission"
+          },
+          "type": "array",
+          "description": "Permissions nested under this one"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     },
     "EmiQueryField": {
       "properties": {


### PR DESCRIPTION
Adds a permission section into the emi, and implements it in Kotlin, Swift, Js, and Golang compiler.